### PR TITLE
Fix luacheck; minor improvements

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,7 +13,7 @@ ignore = {
     "611", -- disable "line contains only whitespace"
 }
 
-std = "+VT1+VMF"
+std = "+VT1+VT2+VMF"
 
 stds["VMF"] = {
     globals = {
@@ -412,4 +412,10 @@ stds["VT1"] = {
         "UICalibrationView", "profiler_scopes_trace", "flow_callback_overcharge_reset_unit",
         "RandomTable_05_05", "POOL_blackboard", "PlayGoTutorialSystem",
     }
+}
+
+stds["VT2"] = {
+    globals = {
+        "IngameViewLayoutLogic", "HeroWindowIngameView",
+    },
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -22,7 +22,7 @@ stds["VMF"] = {
 }
 
 stds["VT1"] = {
-    globals = {
+    read_globals = {
         string = { fields = { "split" }},
         debug = { fields = {
             "load_level", "level_loaded", "spawn_hero", "animation_log_specific_profile", "upvaluejoin", "upvalueid"
@@ -415,7 +415,7 @@ stds["VT1"] = {
 }
 
 stds["VT2"] = {
-    globals = {
+    read_globals = {
         "IngameViewLayoutLogic", "HeroWindowIngameView",
     },
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -17,15 +17,15 @@ std = "+VT1+VT2+VMF"
 
 stds["VMF"] = {
     globals = {
-        "new_mod", "get_mod", "VMFMod", "VMFModsKeyMap", "VMFOptionsView", "VT1"
-    }
+        "new_mod", "get_mod", "VMFMod", "VMFModsKeyMap", "VMFOptionsView", "VT1",
+    },
 }
 
 stds["VT1"] = {
     read_globals = {
         string = { fields = { "split" }},
         debug = { fields = {
-            "load_level", "level_loaded", "spawn_hero", "animation_log_specific_profile", "upvaluejoin", "upvalueid"
+            "load_level", "level_loaded", "spawn_hero", "animation_log_specific_profile", "upvaluejoin", "upvalueid",
         }},
         table = { fields = {
             "merge", "table_to_array", "mirror_table", "tostring", "is_empty", "array_to_table", "reverse", "shuffle",
@@ -411,7 +411,7 @@ stds["VT1"] = {
         "TelemetryEvents", "debug_bot_transitions", "FreeFlightControllerSettings","ApexClothQuality",
         "UICalibrationView", "profiler_scopes_trace", "flow_callback_overcharge_reset_unit",
         "RandomTable_05_05", "POOL_blackboard", "PlayGoTutorialSystem",
-    }
+    },
 }
 
 stds["VT2"] = {


### PR DESCRIPTION
Adds missing VT2 globals so the travis build passes.

Additionally:

+ Sets VT game globals as read-only.
  + Has No effect as the related warnings (121 and 122) are disabled.
+ Add missing trailing commas.
  + So they are consistent accross the file.