### PR TITLE
Hook fixes

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -44,9 +44,11 @@ local _origs = {}
 -- This will tell us if we already have the given function in our registry.
 local function is_orig_hooked(obj, method)
     local orig_registry = _origs
-    if obj and orig_registry[obj] and orig_registry[obj][method] then
-        return true
-    elseif orig_registry[method] then
+    if obj then
+        if orig_registry[obj] and orig_registry[obj][method] then
+            return true
+        end
+    elseif not obj and orig_registry[method] then
         return true
     end
     return false

--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -250,11 +250,9 @@ end
 --     mod, table (obj), string (method), function (handler), string (func_name)
 -- Giving a method string and a hook function (hooking global functions)
 --     mod, string (method), function (handler), nil, string (func_name)
--- Giving a nil value followed by a method stirng and hook function (alternate way for global functions)
---     mod, nil, string (method), function (handler), string (func_name)
 
 local function generic_hook(mod, obj, method, handler, func_name)
-    if vmf.check_wrong_argument_type(mod, func_name, "obj", obj, "string", "table", "nil") or
+    if vmf.check_wrong_argument_type(mod, func_name, "obj", obj, "string", "table") or
        vmf.check_wrong_argument_type(mod, func_name, "method", method, "string", "function") or
        vmf.check_wrong_argument_type(mod, func_name, "handler", handler, "function", "nil")
     then
@@ -262,7 +260,7 @@ local function generic_hook(mod, obj, method, handler, func_name)
     end
 
     -- Shift the arguments if needed
-    if type(method) == "function" then
+    if not handler then
         obj, method, handler = nil, obj, method
         if not method then
             mod:error("(%s): trying to create hook without giving a method name.", func_name)

--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -350,7 +350,9 @@ end
 
 local function toggle_all_hooks_for_mod(mod, enabled_state)
     local toggle_status = (enabled_state and "Enabling") or "Disabling"
-    mod:info("(hooks): %s all hooks for mod: %s", toggle_status, mod:get_name())
+    if next(_registry[mod]) then
+        mod:info("(hooks): %s all hooks for mod: %s", toggle_status, mod:get_name())
+    end
     for _, hook_data in pairs(_registry[mod]) do
         hook_data.active = enabled_state
     end


### PR DESCRIPTION
1) Fixed a flaw in is_orig_hooked() that said a function was already hooked if you hooked a global function by the same name. 
2) It was possible to hook a global function by sending an explicit nil for the obj, but it hindsight that can lead to a lot of issues due to being unable to differentiate a nil and a variable with a typo. 
3) Fixed printing "Enabling/Disable hooks for mod X" for mods that dont hook stuff.