### PR TITLE
Add upvalues core module [RFC]

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -42,7 +42,7 @@ local _origs = {}
 -- ####################################################################################################################
 
 -- This will tell us if we already have the given function in our registry.
-local function vmf.is_orig_hooked(obj, method)
+local function is_orig_hooked(obj, method)
     local orig_registry = _origs
     if obj then
         if orig_registry[obj] and orig_registry[obj][method] then
@@ -58,13 +58,13 @@ end
 -- This will grab the cached reference if we hooked it before, otherwise return the function.
 function vmf.get_orig_function(obj, method)
     if obj then
-        if vmf.is_orig_hooked(obj, method) then
+        if is_orig_hooked(obj, method) then
             return _origs[obj][method]
         else
             return obj[method]
         end
     else
-        if vmf.is_orig_hooked(obj, method) then
+        if is_orig_hooked(obj, method) then
             return _origs[method]
         else
             return rawget(_G, method)
@@ -200,7 +200,7 @@ end
 local function create_hook(mod, orig, obj, method, handler, func_name, hook_type)
     mod:info("(%s): Hooking '%s' from [%s] (Origin: %s)", func_name, method, obj or "_G", orig)
 
-    if not vmf.is_orig_hooked(obj, method) then
+    if not is_orig_hooked(obj, method) then
         create_internal_hook(orig, obj, method)
     end
 

--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -42,7 +42,7 @@ local _origs = {}
 -- ####################################################################################################################
 
 -- This will tell us if we already have the given function in our registry.
-local function is_orig_hooked(obj, method)
+local function vmf.is_orig_hooked(obj, method)
     local orig_registry = _origs
     if obj then
         if orig_registry[obj] and orig_registry[obj][method] then
@@ -56,15 +56,15 @@ end
 
 -- Since we replace the original function, we need to keep its reference around.
 -- This will grab the cached reference if we hooked it before, otherwise return the function.
-local function get_orig_function(obj, method)
+function vmf.get_orig_function(obj, method)
     if obj then
-        if is_orig_hooked(obj, method) then
+        if vmf.is_orig_hooked(obj, method) then
             return _origs[obj][method]
         else
             return obj[method]
         end
     else
-        if is_orig_hooked(obj, method) then
+        if vmf.is_orig_hooked(obj, method) then
             return _origs[method]
         else
             return rawget(_G, method)
@@ -200,7 +200,7 @@ end
 local function create_hook(mod, orig, obj, method, handler, func_name, hook_type)
     mod:info("(%s): Hooking '%s' from [%s] (Origin: %s)", func_name, method, obj or "_G", orig)
 
-    if not is_orig_hooked(obj, method) then
+    if not vmf.is_orig_hooked(obj, method) then
         create_internal_hook(orig, obj, method)
     end
 
@@ -297,7 +297,7 @@ local function generic_hook(mod, obj, method, handler, func_name)
         return
     end
 
-    local orig = get_orig_function(obj, method)
+    local orig = vmf.get_orig_function(obj, method)
     if type(orig) ~= "function" then
         mod:error("(%s): trying to hook %s (a %s), not a function.", func_name, method, type(orig))
         return
@@ -338,7 +338,7 @@ local function generic_hook_toggle(mod, obj, method, enabled_state)
         end
     end
 
-    local orig = get_orig_function(obj, method)
+    local orig = vmf.get_orig_function(obj, method)
 
     if _registry[mod][orig] then
         _registry[mod][orig].active = enabled_state

--- a/vmf/scripts/mods/vmf/modules/core/upvalues.lua
+++ b/vmf/scripts/mods/vmf/modules/core/upvalues.lua
@@ -1,98 +1,118 @@
 local vmf = get_mod("VMF")
 
 
+-- ####################################################################################################################
+-- ##### Locals and Variables #####################################################################################{{{1
+-- ####################################################################################################################
+
+
+-- A registry of all upvalue changes.
+local _upvalue_registry = setmetatable({}, { __mode = "k" })
+--[[ SCHEMA:
+      {
+        [FUNC] = {
+          [UPVALUE_INDEX] = {
+            mod = MOD,
+            orig = ORIGINAL_VALUE,
+            func = FUNC,
+            index = UPVALUE_INDEX,
+          },
+        },
+      }
+--]]
+
+
+-- Same data tables, but regrouped by the mod that did the changes.
+local _upvalues_by_mod = {}
+--[[ SCHEMA:
+      {
+        [{
+          mod = MOD,
+          orig = ORIGINAL_VALUE,
+          func = FUNC,
+          index = UPVALUE_INDEX,
+        }] = true,
+      }
+--]]
+
+
 -- #####################################################################################################################
 -- ##### Local functions ###########################################################################################{{{1
 -- #####################################################################################################################
 
--- Given a function, a string or a table+string; we resolve it into a function (taking into account hooks).
+-- Given an argument list, it tries to resolve up to two arguments into a function. The following forms are accepted:
+-- Object (table) + Method (string)
+-- Global function name (string)
+-- Raw function (function)
 local function resolve_function(mod, vmf_func_name, obj, method, ...)
-  if vmf.check_wrong_argument_type(mod, vmf_func_name, "obj", obj, "function", "string", "table")
-  then return nil end
+  if vmf.check_wrong_argument_type(mod, vmf_func_name, "obj", obj, "function", "string", "table") then
+    return nil
+  end
 
   local type_obj = type(obj)
 
-  -- If it's already a function, we return it as-is followed by the rest of the arguments.
+  -- If the first argument is already a function, the argument list is returned as-is.
   if type_obj == "function" then
     return obj, method, ...
-  end
-
-  -- If it's a string, we unshift the arguments.
-  if type_obj == "string" then
+  -- If it's a string, we unshift a nil into the arguments and proceed.
+  elseif type_obj == "string" then
     obj, method = nil, obj
+  -- Otherwise, it's a table and we must ensure that the next argument is a string.
+  elseif vmf.check_wrong_argument_type(mod, vmf_func_name, "method", method, "string") then
+    return nil
   end
 
-  -- At this point, the method argument must always be a string.
-  if vmf.check_wrong_argument_type(mod, vmf_func_name, "method", method, "string")
-  then return nil end
-
+  -- Get the raw function referenced by obj[method], followed by other arguments.
   return vmf.get_orig_function(obj, method), ...
 end
 
 
--- Return the next upvalue triplet by index.
-local function upvalue_next(func, i)
-  i = i and i+1 or 1
-  local k, v = debug.getupvalue(func, i)
-  if k then
-    return i, k, v
+-- Retrieve the value and index associated to an upvalue.
+local function upvalue_get(func, name)
+  local i = 1
+  while true do
+    local k, v = debug.getupvalue(func, i)
+    if not k then
+      return
+    elseif k == name then
+      return v, i
+    end
   end
 end
 
 
--- Convenience function for use in `for` loops.
-local function upvalue_iterate(func)
-  return upvalue_next, func, nil
+local ERRORS = {
+  no_such_upvalue = "no such upvalue: '%s'",
+  not_upvalue_owner = "upvalue '%s' modified by another mod '%s'",
+}
+
+local function show_error(mod, error_prefix_data, error_fmt, ...)
+  mod:error("(%s): %s", error_prefix_data, string.format(error_fmt, ...))
+end
+
+
+-- Function intended to be used as the __newindex field. Disallows writes in the table.
+local function error_on_write(obj, key)
+  return vmf:error("cannot set field '%s' on protected metatable '%s'", key, obj)
+end
+
+
+local function protect_value(value)
+  if type(value) == "table" then
+    value = setmetatable({}, {
+      __metatable = true, -- Protect the metatable
+      __newindex = error_on_write, -- Disallow writes.
+      __index = value, -- Proxy reads to the original table.
+    })
+  end
+
+  return value
 end
 
 
 -- #####################################################################################################################
 -- ##### VMFMod ####################################################################################################{{{1
 -- #####################################################################################################################
-
---- Analog to `next` for upvalues. Returns the triplet at the next index.
--- @param i Upvalue index
--- @returns The index, key and value of the next upvalue.
-function VMFMod:upvalue_next(obj, method, i)
-  local func
-  func, i = resolve_function(self, "upvalue_next", obj, method, i)
-
-  if not func
-  or vmf.check_wrong_argument_type(self, "upvalue_next", "i", i, "nil", "number")
-  then return end
-
-
-  return upvalue_next(func, i)
-end
-
-
---- Convenience generic upvalue iterator.
--- For use in Lua's `for in` loop structure.
--- @param name The name of the upvalue.
--- @returns The `upvalue_next` function, func and nil.
-function VMFMod:upvalue_iterate(obj, method)
-  local func = resolve_function(self, "upvalue_iterate", obj, method)
-
-  return upvalue_next, func, nil
-end
-
-
---- Build a table with all the upvalues.
--- @returns A table of upvalue key and value pairs.
-function VMFMod:upvalue_table(obj, method)
-  local func = resolve_function(self, "upvalue_table", obj, method)
-
-  if not func
-  then return end
-
-
-  local t = {}
-  for _, k, v in upvalue_iterate(func) do
-    t[k] = v
-  end
-  return t
-end
-
 
 --- Retrieve an upvalue by name.
 -- @param name The name of the upvalue.
@@ -101,38 +121,135 @@ function VMFMod:upvalue_get(obj, method, upvalue_name)
   local func
   func, upvalue_name = resolve_function(self, "upvalue_get", obj, method, upvalue_name)
 
-  if not func
-  or vmf.check_wrong_argument_type(self, "upvalue_get", "upvalue_name", upvalue_name, "string")
-  then return end
-
-
-  for _, k, v in upvalue_iterate(func) do
-    if upvalue_name == k then
-      return v
-    end
+  -- Type-check the arguments.
+  if not func or
+     vmf.check_wrong_argument_type(self, "upvalue_get", "upvalue_name", upvalue_name, "string")
+  then
+    return
   end
-  return nil
+
+  local value, index = upvalue_get(func, upvalue_name)
+  return protect_value(value), index
 end
 
 
 --- Modify an upvalue by name.
--- @param name The name of the upvalue.
--- @param value The new value.
+-- @param upvalue_name The name of the upvalue.
+-- @param new_value The new value.
 -- @returns The name of the upvalue if it was changed and nil otherwise.
 function VMFMod:upvalue_set(obj, method, upvalue_name, new_value)
   local func
   func, upvalue_name, new_value = resolve_function(self, "upvalue_set", obj, method, upvalue_name, new_value)
 
-  if not func
-  or vmf.check_wrong_argument_type(self, "upvalue_set", "func", func, "function")
-  or vmf.check_wrong_argument_type(self, "upvalue_set", "upvalue_name", upvalue_name, "string")
-  then return end
+  -- Type-check the arguments.
+  if not func or
+     vmf.check_wrong_argument_type(self, "upvalue_set", "upvalue_name", upvalue_name, "string")
+  then
+    return
+  end
+
+  -- Get the index of the upvalue. Fail if it doesn't exist.
+  local current_value, index = upvalue_get(func, upvalue_name)
+  if not index then
+    return show_error(mod, "upvalue_set", ERRORS.no_such_upvalue, upvalue_name)
+  end
+
+  -- Lookup the function in the upvalue registry. Register it if wasn't found.
+  if not _upvalue_registry[func] then
+    _upvalue_registry[func] = {}
+  end
+  local func_upvalues = _upvalue_registry[func]
+
+  -- If we have no data registered for this upvalue, we register it.
+  if not func_upvalues[index] then
+    local upvalue_data = {
+      mod = mod,
+      orig = current_value,
+      func = func,
+      index = index,
+    }
+    func_upvalues[index] = upvalue_data
+    _upvalues_by_mod[mod][upvalue_data] = true
+
+  -- Otherwise, we make sure that it wasn't modified by another mod.
+  elseif func_upvalues[index].mod ~= mod then
+    local other_mod_name = upvalue_data.mod:get_name()
+    return show_error(mod, "upvalue_set", ERRORS.not_upvalue_owner, upvalue_name, other_mod_name)
+  end
+
+  -- All good, we modify the upvalue.
+  debug.setupvalue(func, index, new_value)
+end
 
 
-  for i, k, _ in upvalue_iterate(func) do
-    if upvalue_name == k then
-      return debug.setupvalue(func, i, new_value)
+--- Reset an upvalue to its original value and relinquish ownership of it.
+-- @param upvalue_name The name of the upvalue.
+-- @returns The name of the upvalue if it was reset and nil otherwise.
+function VMFMod:upvalue_unset(obj, method, upvalue_name)
+  local func
+  func, upvalue_name, new_value = resolve_function(self, "upvalue_unset", obj, method, upvalue_name, new_value)
+
+  -- Type-check the arguments.
+  if not func or
+     vmf.check_wrong_argument_type(self, "upvalue_unset", "upvalue_name", upvalue_name, "string")
+  then
+    return
+  end
+
+  -- Get the index of the upvalue. Fail if it doesn't exist.
+  local current_value, index = upvalue_get(func, upvalue_name)
+  if not index then
+    return show_error(mod, "upvalue_unset", ERRORS.no_such_upvalue, upvalue_name)
+  end
+
+  -- Lookup the function in the upvalue registry. Nothing to do if there are no changes.
+  local func_upvalues = _upvalue_registry[func]
+  if not func_upvalues then
+    return
+  end
+
+  -- If we have no data registed for this upvalue, we do nothing and return.
+  local upvalue_data = func_upvalues[index]
+  if not upvalue_data then
+    return -- Nothing to do
+
+  -- Otherwise, we make sure that it wasn't modified by another mod.
+  elseif func_upvalues[index].mod ~= mod then
+    local other_mod_name = upvalue_data.mod:get_name()
+    return show_error(mod, "upvalue_unset", ERRORS.not_upvalue_owner, upvalue_name, other_mod_name)
+  end
+
+  -- Restore the upvalue.
+  debug.setupvalue(func, index, upvalue_data.orig)
+
+  -- Clean our records.
+  upvalue_data[index] = nil
+  _upvalues_by_mod[mod][upvalue_data] = nil
+
+  return
+end
+
+function VMFMod:upvalue_unset_all()
+  local mod_upvalues = _upvalues_by_mod[mod]
+  if not mod_upvalues then
+    return
+  end
+
+  for upvalue_data in pairs(mod_upvalues) do
+    debug.setupvalue(upvalue_data.func, upvalue_data.index, upvalue_data.orig)
+  end
+end
+
+
+-- ####################################################################################################################
+-- ##### VMF internal functions and variables #####################################################################{{{1
+-- ####################################################################################################################
+
+-- Restore all upvalues when VMF is about to be reloaded.
+function vmf.upvalues_unload()
+  for func, upvalue_data in pairs(_upvalue_registry) do
+    for index, upvalue_data in pairs(upvalue_data) do
+      debug.setupvalue(func, index, upvalue_data.orig)
     end
   end
-  return nil
 end

--- a/vmf/scripts/mods/vmf/modules/core/upvalues.lua
+++ b/vmf/scripts/mods/vmf/modules/core/upvalues.lua
@@ -1,0 +1,132 @@
+local vmf = get_mod("VMF")
+
+
+-- #####################################################################################################################
+-- ##### Local functions ###########################################################################################{{{1
+-- #####################################################################################################################
+
+-- Given a function, a string or a table+string; we resolve it into a function (taking into account hooks).
+local function resolve_function(mod, vmf_func_name, obj, method, ...)
+  if vmf.check_wrong_argument_type(mod, vmf_func_name, "obj", obj, "function", "string", "table")
+  then return nil end
+
+  local type_obj = type(obj)
+
+  -- If it's already a function, we return it as-is followed by the rest of the arguments.
+  if type_obj == "function" then
+    return obj, method, ...
+  end
+
+  -- If it's a string, we unshift the arguments.
+  if type_obj == "string" then
+    obj, method = nil, obj
+  end
+
+  -- At this point, the method argument must always be a string.
+  if vmf.check_wrong_argument_type(mod, vmf_func_name, "method", method, "string")
+  then return nil end
+
+  return vmf.get_orig_function(obj, method), ...
+end
+
+
+-- Return the next upvalue triplet by index.
+local function upvalue_next(func, i)
+  i = i and i+1 or 1
+  local k, v = debug.getupvalue(func, i)
+  if k then
+    return i, k, v
+  end
+end
+
+
+-- Convenience function for use in `for` loops.
+local function upvalue_iterate(func)
+  return upvalue_next, func, nil
+end
+
+
+-- #####################################################################################################################
+-- ##### VMFMod ####################################################################################################{{{1
+-- #####################################################################################################################
+
+--- Analog to `next` for upvalues. Returns the triplet at the next index.
+-- @param i Upvalue index
+-- @returns The index, key and value of the next upvalue.
+function VMFMod:upvalue_next(obj, method, i)
+  local func, i = resolve_function(self, "upvalue_next", obj, method, i)
+
+  if not func
+  or vmf.check_wrong_argument_type(self, "upvalue_next", "i", i, "nil", "number")
+  then return end
+
+  return upvalue_next(func, i)
+end
+
+
+--- Convenience generic upvalue iterator.
+-- For use in Lua's `for in` loop structure.
+-- @param name The name of the upvalue.
+-- @returns The `upvalue_next` function, func and nil.
+  function VMFMod:upvalue_iterate(obj, method)
+    local func = resolve_function(self, "upvalue_iterate", obj, method)
+
+    return upvalue_next, func, nil
+end
+
+
+--- Build a table with all the upvalues.
+-- @returns A table of upvalue key and value pairs.
+function VMFMod:upvalue_table(obj, method)
+  local func = resolve_function(self, "upvalue_table", obj, method)
+
+  if not func
+  then return end
+
+  local t = {}
+  for _, k, v in upvalue_iterate(func) do
+    t[k] = v
+  end
+  return t
+end
+
+
+--- Retrieve an upvalue by name.
+-- @param name The name of the upvalue.
+-- @returns The current value of the upvalue.
+function VMFMod:upvalue_get(obj, method, upvalue_name)
+  local func, upvalue_name = resolve_function(self, "upvalue_get", obj, method, upvalue_name)
+
+  if not func
+  or vmf.check_wrong_argument_type(self, "upvalue_get", "upvalue_name", upvalue_name, "string")
+  then return end
+
+  for _, k, v in upvalue_iterate(func) do
+    if upvalue_name == k then
+      return v
+    end
+  end
+  return nil
+end
+
+
+--- Modify an upvalue by name.
+-- @param name The name of the upvalue.
+-- @param value The new value.
+-- @returns The name of the upvalue if it was changed and nil otherwise.
+function VMFMod:upvalue_set(obj, method, upvalue_name, new_value)
+  local func, upvalue_name, new_value = resolve_function(self, "upvalue_set", obj, method, upvalue_name, new_value)
+
+
+  if not func
+  or vmf.check_wrong_argument_type(self, "upvalue_set", "func", func, "function")
+  or vmf.check_wrong_argument_type(self, "upvalue_set", "upvalue_name", upvalue_name, "string")
+  then return end
+
+  for i, k, v in upvalue_iterate(func) do
+    if upvalue_name == k then
+      return debug.setupvalue(func, i, new_value)
+    end
+  end
+  return nil
+end

--- a/vmf/scripts/mods/vmf/modules/core/upvalues.lua
+++ b/vmf/scripts/mods/vmf/modules/core/upvalues.lua
@@ -54,11 +54,13 @@ end
 -- @param i Upvalue index
 -- @returns The index, key and value of the next upvalue.
 function VMFMod:upvalue_next(obj, method, i)
-  local func, i = resolve_function(self, "upvalue_next", obj, method, i)
+  local func
+  func, i = resolve_function(self, "upvalue_next", obj, method, i)
 
   if not func
   or vmf.check_wrong_argument_type(self, "upvalue_next", "i", i, "nil", "number")
   then return end
+
 
   return upvalue_next(func, i)
 end
@@ -68,10 +70,10 @@ end
 -- For use in Lua's `for in` loop structure.
 -- @param name The name of the upvalue.
 -- @returns The `upvalue_next` function, func and nil.
-  function VMFMod:upvalue_iterate(obj, method)
-    local func = resolve_function(self, "upvalue_iterate", obj, method)
+function VMFMod:upvalue_iterate(obj, method)
+  local func = resolve_function(self, "upvalue_iterate", obj, method)
 
-    return upvalue_next, func, nil
+  return upvalue_next, func, nil
 end
 
 
@@ -82,6 +84,7 @@ function VMFMod:upvalue_table(obj, method)
 
   if not func
   then return end
+
 
   local t = {}
   for _, k, v in upvalue_iterate(func) do
@@ -95,11 +98,13 @@ end
 -- @param name The name of the upvalue.
 -- @returns The current value of the upvalue.
 function VMFMod:upvalue_get(obj, method, upvalue_name)
-  local func, upvalue_name = resolve_function(self, "upvalue_get", obj, method, upvalue_name)
+  local func
+  func, upvalue_name = resolve_function(self, "upvalue_get", obj, method, upvalue_name)
 
   if not func
   or vmf.check_wrong_argument_type(self, "upvalue_get", "upvalue_name", upvalue_name, "string")
   then return end
+
 
   for _, k, v in upvalue_iterate(func) do
     if upvalue_name == k then
@@ -115,15 +120,16 @@ end
 -- @param value The new value.
 -- @returns The name of the upvalue if it was changed and nil otherwise.
 function VMFMod:upvalue_set(obj, method, upvalue_name, new_value)
-  local func, upvalue_name, new_value = resolve_function(self, "upvalue_set", obj, method, upvalue_name, new_value)
-
+  local func
+  func, upvalue_name, new_value = resolve_function(self, "upvalue_set", obj, method, upvalue_name, new_value)
 
   if not func
   or vmf.check_wrong_argument_type(self, "upvalue_set", "func", func, "function")
   or vmf.check_wrong_argument_type(self, "upvalue_set", "upvalue_name", upvalue_name, "string")
   then return end
 
-  for i, k, v in upvalue_iterate(func) do
+
+  for i, k, _ in upvalue_iterate(func) do
     if upvalue_name == k then
       return debug.setupvalue(func, i, new_value)
     end

--- a/vmf/scripts/mods/vmf/vmf_loader.lua
+++ b/vmf/scripts/mods/vmf/vmf_loader.lua
@@ -95,6 +95,7 @@ function vmf_mod_object:on_reload()
   vmf.remove_custom_views()
   vmf.unload_all_resource_packages()
   vmf.hooks_unload()
+  vmf.upvalues_unload()
   vmf.reset_guis()
 end
 

--- a/vmf/scripts/mods/vmf/vmf_loader.lua
+++ b/vmf/scripts/mods/vmf/vmf_loader.lua
@@ -37,6 +37,7 @@ function vmf_mod_object:init()
   dofile("scripts/mods/vmf/modules/ui/chat/chat_actions")
   dofile("scripts/mods/vmf/modules/ui/options/mod_options")
   dofile("scripts/mods/vmf/modules/vmf_options")
+  dofile("scripts/mods/vmf/modules/core/upvalues")
 
   if VT1 then
     dofile("scripts/mods/vmf/modules/core/mutators/mutators_manager")


### PR DESCRIPTION
This is a **request for comments** on a possible implementation of an upvalue manipulation module for VMF as suggested by @unshame in issue #5.

## API

```lua
--- Analog to `next` for upvalues. Returns the triplet at the next index.
function VMFMod:upvalue_next(obj, method, i)

--- Convenience generic upvalue iterator. For use in Lua's `for` loops.
function VMFMod:upvalue_iterate(obj, method)

--- Build a table with all the upvalues.
function VMFMod:upvalue_table(obj, method)

--- Retrieve an upvalue by name.
function VMFMod:upvalue_get(obj, method, upvalue_name)

--- Modify an upvalue by name.
function VMFMod:upvalue_set(obj, method, upvalue_name, new_value)
```

All methods have 3 different forms they can be called:

```lua
mod:upvalue_table(MatchmakingManager, "all_peers_ready") -- Object + method
mod:upvalue_table("career_index_from_name") -- A global function name
mod:upvalue_table(FindProfileIndex) -- A raw function
```

### To-do list

- [x] Fix the indendation of `upvalue_iterate`.
- [ ] Thoroughtly test all the methods (there are currently untested changes).
- [ ] **Maybe?** Warn users if they set an upvalue of a function that has been modified by hook origin.
- [x] **Maybe?** Impose restrictions proposed in #5.

---
Thoughts? Comments?