### PR TITLE
Flexible mod resources

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/localization.lua
+++ b/vmf/scripts/mods/vmf/modules/core/localization.lua
@@ -71,11 +71,11 @@ end
 -- ##### VMF internal functions and variables #########################################################################
 -- ####################################################################################################################
 
-vmf.load_mod_localization = function (mod, localization_table)
+vmf.initialize_mod_localization = function (mod, localization_table)
 
   if type(localization_table) ~= "table" then
     mod:error("(localization): localization file should return table")
-    return
+    return false
   end
 
   if _localization_database[mod:get_name()] then
@@ -83,6 +83,8 @@ vmf.load_mod_localization = function (mod, localization_table)
   end
 
   _localization_database[mod:get_name()] = localization_table
+
+  return true
 end
 
 -- Localize without parameters and return nil instead of <text_id> if nothing found
@@ -101,4 +103,4 @@ end
 -- ####################################################################################################################
 
 local localization_table = vmf:dofile("localization/vmf")
-vmf.load_mod_localization(vmf, localization_table)
+vmf.initialize_mod_localization(vmf, localization_table)

--- a/vmf/scripts/mods/vmf/modules/core/mutators/test/mutators_test.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/test/mutators_test.lua
@@ -1,11 +1,11 @@
 local vmf = get_mod("VMF")
 
-local function create_test_mutator(name, mod_data)
+local function create_test_mutator(mod_name, mod_data)
   return new_mod(mod_name, {
     mod_data = mod_data,
     mod_script = function()
-      local mod = get_mod(name)
-      local readable_name = mod_data.name or name
+      local mod = get_mod(mod_name)
+      local readable_name = mod_data.name or mod_name
       function mod.on_enabled(init_call)
         mod:echo("%s on_enabled(%s)", readable_name, init_call and "init" or "")
       end

--- a/vmf/scripts/mods/vmf/modules/core/mutators/test/mutators_test.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/test/mutators_test.lua
@@ -1,261 +1,145 @@
 local vmf = get_mod("VMF")
 
-local mod
-local mod_data
+local function create_test_mutator(name, mod_data)
+  return new_mod(mod_name, {
+    mod_data = mod_data,
+    mod_script = function()
+      local mod = get_mod(name)
+      local readable_name = mod_data.name or name
+      function mod.on_enabled(init_call)
+        mod:echo("%s on_enabled(%s)", readable_name, init_call and "init" or "")
+      end
+      function mod.on_disabled(init_call)
+        mod:echo("%s on_disabled(%s)", readable_name, init_call and "init" or "")
+      end
+    end
+  })
+end
 
 ----------------------------------------------------------------------------------
 
-new_mod("test_legendary", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_legendary")
-mod_data = {}
-mod_data.name = "Legendary"
-mod_data.description = "Legendary description"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  incompatible_with_all = true,
-  compatible_with = {
-    "test_something"
-  }
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("Legendary on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("Legendary on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-----------------------------------------------------------------------------------
-
-new_mod("test_something", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_something")
-mod_data = {}
-mod_data.name = "Something"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  incompatible_with = {
-    "test_true_solo",
-    "test_slayer"
-  }
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("Something on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("Something on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-----------------------------------------------------------------------------------
-
-new_mod("test_deathwish", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_deathwish")
-mod_data = {}
-mod_data.name = "?Deathwish"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  difficulty_levels = {
-    "hardest",
-    "survival_hardest"
+create_test_mutator("test_legendary", {
+  name = "Legendary",
+  description = "Legendary description",
+  is_mutator = true,
+  mutator_settings = {
+    incompatible_with_all = true,
+    compatible_with = {
+      "test_something"
+    },
   },
-  title_placement = "after"
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("?Deathwish on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("?Deathwish on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+})
 
 ----------------------------------------------------------------------------------
 
-new_mod("test_slayer", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_slayer")
-mod_data = {}
-mod_data.name = "Slayer's Oath"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  difficulty_levels = {
-    "survival_hard",
-    "survival_harder",
-    "survival_hardest"
-  }
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("Slayer's Oath on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("Slayer's Oath on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+create_test_mutator("test_something", {
+  name = "Something",
+  is_mutator = true,
+  mutator_settings = {
+    incompatible_with = {
+      "test_true_solo",
+      "test_slayer",
+    },
+  },
+})
 
 ----------------------------------------------------------------------------------
 
-new_mod("test_true_solo", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_true_solo")
-mod_data = {}
-mod_data.name = "True Solo"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  compatible_with_all = true,
-  title_placement = "before"
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("True Solo on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("True Solo on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+create_test_mutator("test_deathwish", {
+  name = "?Deathwish",
+  is_mutator = true,
+  mutator_settings = {
+    difficulty_levels = {
+      "hardest",
+      "survival_hardest",
+    },
+    title_placement = "after",
+  },
+})
 
 ----------------------------------------------------------------------------------
 
-new_mod("test_onslaught", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_onslaught")
-mod_data = {}
-mod_data.name = "Onslaught"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("Onslaught on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("Onslaught on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+create_test_mutator("test_slayer", {
+  name = "Slayer's Oath",
+  is_mutator = true,
+  mutator_settings = {
+    difficulty_levels = {
+      "survival_hard",
+      "survival_harder",
+      "survival_hardest",
+    },
+  },
+})
 
 ----------------------------------------------------------------------------------
 
-new_mod("test_one_hit_one_kill", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_one_hit_one_kill")
-mod_data = {}
-mod_data.name = "One Hit One Kill"
-mod_data.description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse tincidunt placerat" ..
-                       " nulla eget pharetra. Vivamus consequat tristique vestibulum. Nullam vitae feugiat arcu," ..
-                       " non porta ante. Phasellus consequat facilisis quam quis dignissim"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  difficulty_levels = {"hardest"},
-  enable_after_these = {"test_more_rats_weapons"}
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("One Hit One Kill on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("One Hit One Kill on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+create_test_mutator("test_true_solo", {
+  name = "True Solo",
+  is_mutator = true,
+  mutator_settings = {
+    compatible_with_all = true,
+    title_placement = "before",
+  },
+})
 
 ----------------------------------------------------------------------------------
 
-new_mod("ayyyy", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("ayyyy")
-mod_data = {}
-mod_data.name = "ayyyy"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("ayyyy on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("ayyyy on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-----------------------------------------------------------------------------------
-
-new_mod("lmao", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("lmao")
-mod_data = {}
-mod_data.name = "lmao"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  difficulty_levels = {"hardest"},
-  enable_after_these = {"ayyyy"},
-  dice = {
-    bonus = 2
-  }
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("lmao on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("lmao on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+create_test_mutator("test_onslaught", {
+  name = "Onslaught",
+  is_mutator = true,
+})
 
 ----------------------------------------------------------------------------------
 
-new_mod("test_more_rats_weapons", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("test_more_rats_weapons")
-mod_data = {}
-mod_data.name = "More Rat Weapons"
-mod_data.is_mutator = true
-mod_data.mutator_settings = {
-  compatible_with_all = true,
-  difficulty_levels = {"hardest"}
-}
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("More Rat Weapons on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("More Rat Weapons on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+create_test_mutator("test_one_hit_one_kill", {
+  name = "One Hit One Kill",
+  description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse tincidunt placerat" ..
+                         " nulla eget pharetra. Vivamus consequat tristique vestibulum. Nullam vitae feugiat arcu," ..
+                         " non porta ante. Phasellus consequat facilisis quam quis dignissim",
+  is_mutator = true,
+  mutator_settings = {
+    difficulty_levels = {"hardest"},
+    enable_after_these = {"test_more_rats_weapons"},
+  },
+})
+
+----------------------------------------------------------------------------------
+
+create_test_mutator("ayyyy", {
+  name = "ayyyy",
+  is_mutator = true,
+})
+
+----------------------------------------------------------------------------------
+
+create_test_mutator("lmao", {
+  name = "lmao",
+  is_mutator = true,
+  mutator_settings = {
+    difficulty_levels = {"hardest"},
+    enable_after_these = {"ayyyy"},
+    dice = {
+      bonus = 2,
+    },
+  },
+})
+
+----------------------------------------------------------------------------------
+
+create_test_mutator("test_more_rats_weapons", {
+  name = "More Rat Weapons",
+  is_mutator = true,
+  mutator_settings = {
+    compatible_with_all = true,
+    difficulty_levels = {"hardest"},
+  },
+})
 
 --[[ -- scrollbar test
-new_mod("111", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("111")
-mod_data = {}
-mod_data.name = "111"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("111 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("111 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-
-new_mod("222", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("222")
-mod_data = {}
-mod_data.name = "222"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("222 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("222 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-
-new_mod("333", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("333")
-mod_data = {}
-mod_data.name = "333"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("333 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("333 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-
-new_mod("444", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("444")
-mod_data = {}
-mod_data.name = "444"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("444 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("444 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-
-new_mod("555", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("555")
-mod_data = {}
-mod_data.name = "555"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("555 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("555 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-
-new_mod("666", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("666")
-mod_data = {}
-mod_data.name = "666"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("666 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("666 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-
-new_mod("777", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("777")
-mod_data = {}
-mod_data.name = "777"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("777 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("777 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
-
-
-new_mod("888", {mod_script = "scripts/mods/vmf/modules/core/mutators/test/mutators_test_empty_file"})
-mod = get_mod("888")
-mod_data = {}
-mod_data.name = "888"
-mod_data.is_mutator = true
-vmf.initialize_mod_data(mod, mod_data)
-mod.on_enabled = function(init_call) mod:echo("888 on_enabled(" .. (init_call and "init)" or ")")) end
-mod.on_disabled = function(init_call) mod:echo("888 on_disabled(" .. (init_call and "init)" or ")")) end
-vmf.initialize_mod_state(mod)
+for i=1, 8 do
+  create_test_mutator("test_more_rats_weapons", {
+    name = i .. i .. i,
+    is_mutator = true,
+  })
+end
 --]]

--- a/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
@@ -52,7 +52,7 @@ local function resolve_resource(mod, error_prefix_data, resource, resource_value
   if type_value == "string" then
     return vmf.safe_call_dofile(mod, error_prefix_data, resource_value)
   elseif type_value == "function" then
-    return vmf.safe_call(mod, error_prefix_data, resource_value)
+    return vmf.safe_call(mod, error_prefix_data, resource_value, mod)
   elseif type_value == "table" then
     return true, type_value
   end

--- a/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
@@ -12,10 +12,6 @@ local ERRORS = {
     mod_name_wrong_type = "[VMF Mod Manager] (new_mod): first argument ('mod_name') should be a string, not %s.",
     mod_resources_wrong_type = "[VMF Mod Manager] (new_mod) '%s': second argument ('mod_resources') should be a " ..
                                 "table, not %s.",
-    mod_localization_path_wrong_type = "[VMF Mod Manager] (new_mod) '%s': 'mod_localization' (optional) should be a " ..
-                                        "string, not %s.",
-    mod_data_path_wrong_type = "[VMF Mod Manager] (new_mod) '%s': 'mod_data' (optional) should be a string, not %s.",
-    mod_script_path_wrong_type = "[VMF Mod Manager] (new_mod) '%s': 'mod_script' should be a string, not %s.",
     too_late_for_mod_creation = "[VMF Mod Manager] (new_mod) '%s': you can't create mods after vanilla mod manager " ..
                                  "finishes loading mod bundles.",
     -- vmf.initialize_mod_data:
@@ -49,6 +45,49 @@ local function create_mod(mod_name)
   return mod
 end
 
+-- Resolves a value. If it's a function, executes it. If it's a string, loads the file at that path.
+local function resolve_resource(mod, error_prefix_data, resource, resource_value)
+  local type_value = type(resource_value)
+
+  if type_value == "string" then
+    return vmf.safe_call_dofile(mod, error_prefix_data, resource_value)
+  elseif type_value == "function" then
+    return vmf.safe_call(mod, error_prefix_data, resource_value)
+  elseif type_value == "table" then
+    return true, type_value
+  end
+
+  mod:warning("%s: 'mod_%s' (optional) should be a string, function or table; not %s",
+              error_prefix_data, resource, type_value)
+  return false
+end
+
+local function load_mod_resource(mod, mod_resources, resource)
+  local error_prefix_data = ERRORS.PREFIX["mod_" .. resource .. "_initialization"]
+  local resource_value = mod_resources["mod_" .. resource]
+
+  -- All resources can be optionally be nil.
+  if resource_value == nil then
+    return true
+  end
+
+  -- Resolve the value and obtain the result
+  local success, return_value = resolve_resource(mod, error_prefix_data, resource, resource_value)
+
+  -- Could not resolve the file. An error will already have been printed.
+  if not success then
+    return false
+  end
+
+  -- Check if there's a VMF initializator for this resource, and execute it if it exists.
+  local vmf_initializator = vmf["initialize_mod_" .. resource]
+  if not vmf_initializator then
+    return true
+  end
+
+  return vmf_initializator(mod, return_value)
+end
+
 -- #####################################################################################################################
 -- ##### Public functions ##############################################################################################
 -- #####################################################################################################################
@@ -62,21 +101,9 @@ function new_mod(mod_name, mod_resources)
     vmf:error(ERRORS.REGULAR.mod_resources_wrong_type, mod_name, type(mod_resources))
     return
   end
-  if type(mod_resources.mod_localization) ~= "string" and type(mod_resources.mod_localization) ~= "nil" then
-    vmf:error(ERRORS.REGULAR.mod_localization_path_wrong_type, mod_name, type(mod_resources.mod_localization))
-    return
-  end
-  if type(mod_resources.mod_data) ~= "string" and type(mod_resources.mod_data) ~= "nil" then
-    vmf:error(ERRORS.REGULAR.mod_data_path_wrong_type, mod_name, type(mod_resources.mod_localization))
-    return
-  end
-  if type(mod_resources.mod_script) ~= "string" then
-    vmf:error(ERRORS.REGULAR.mod_script_path_wrong_type, mod_name, type(mod_resources.mod_localization))
-    return
-  end
 
   if vmf.all_mods_were_loaded then
-    vmf:error(ERRORS.REGULAR.too_late_for_mod_creation, mod_name, type(mod_resources.mod_localization))
+    vmf:error(ERRORS.REGULAR.too_late_for_mod_creation, mod_name)
     return
   end
 
@@ -86,28 +113,13 @@ function new_mod(mod_name, mod_resources)
     return
   end
 
-  -- Load localization data file
-  if mod_resources.mod_localization then
-    local success, localization_table = vmf.safe_call_dofile(mod, ERRORS.PREFIX.mod_localization_initialization,
-                                                              mod_resources.mod_localization)
-    if success then
-      vmf.load_mod_localization(mod, localization_table) -- @TODO: return here if not sucessful? rename to "initialize_"
-    else
-      return
-    end
-  end
-
-  -- Load mod data file
-  if mod_resources.mod_data then
-    local success, mod_data_table = vmf.safe_call_dofile(mod, ERRORS.PREFIX.mod_data_initialization,
-                                                          mod_resources.mod_data)
-    if success and not vmf.initialize_mod_data(mod, mod_data_table) then
-      return
-    end
-  end
-
-  -- Load mod
-  if not vmf.safe_call_dofile(mod, ERRORS.PREFIX.mod_script_initialization, mod_resources.mod_script) then
+  -- Load mod components: localization, data and script. NOTE: Order here is important.
+  if not (
+    load_mod_resource(mod, mod_resources, "localization") and
+    load_mod_resource(mod, mod_resources, "data") and
+    load_mod_resource(mod, mod_resources, "script") -- @TODO: Check that this isn't a table.
+  )
+  then
     return
   end
 
@@ -115,6 +127,8 @@ function new_mod(mod_name, mod_resources)
   if mod:get_internal_data("is_togglable") then
     vmf.initialize_mod_state(mod)
   end
+
+  return mod
 end
 
 


### PR DESCRIPTION
Allows definining mod resources as either a table, a function or a string.

+ **Table**: used as-is for the given field.
+ **Function**: executed. Return value used.
+ **String**: interpreted as a file path that is executed. Return value used.

Here is an example of all three in action:

```lua
new_mod("my_test_mod", {
  -- Can be a table that is passed as-is.
  mod_localization = {
    mod_name = { en = "Hello, world!" },
  },
  -- Can be a function that is executed.
  mod_data = function(mod)
    local readable_name = mod:localize("mod_name")
    return {
        name = readable_name,
        description = readable_name .. " description",
    }
  end,
  -- Can be a path to a file that will be executed.
  mod_script = "scripts/mods/my_test_mod/main",
})
```

Current issue: `mod_script` can be set to a table, but that does nothing.

*Late edit: updated example.*