### PR TITLE
VMF package manager overhaul

### DIFF
--- a/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
@@ -42,7 +42,7 @@ local function check_vt1(mod, function_name)
 end
 
 
--- Brings the resources in the loaded package in game and executes callback.
+-- Brings resources of the loaded package in game and executes callback.
 local function flush_package(package_name)
   local package_data = _packages[package_name]
   package_data.resource_package:flush()
@@ -71,7 +71,7 @@ end
 --[[
   Loads a mod package.
   * package_name [string]  : package name. needs to be the full path to the `.package` file without the extension
-  * callback     [function]: (optional) callback for asynchronous loading
+  * callback     [function]: (optional) callback for when loading is done
   * sync         [boolean] : (optional) load the packages synchronously, freezing the game until it is loaded
 --]]
 function VMFMod:load_package(package_name, callback, sync)
@@ -107,7 +107,7 @@ function VMFMod:load_package(package_name, callback, sync)
   end
 
   if sync then
-    -- If package wasn't loaded asynchroniously before and is not already loading.
+    -- Load resource package if it's not already loading.
     if _packages[package_name].status == "queued" then
       resource_package:load()
     end
@@ -126,7 +126,7 @@ end
 
 
 --[[
-  Unlaods a loaded mod package.
+  Unloads a loaded mod package.
   * package_name [string]: package name. needs to be the full path to the `.package` file without the extension
 --]]
 function VMFMod:unload_package(package_name)
@@ -174,7 +174,7 @@ end
 -- ##### VMF internal functions and variables ##########################################################################
 -- #####################################################################################################################
 
--- Loads queued packages one at a time
+-- Loads queued packages one at a time.
 function vmf.update_package_manager()
   local queued_package_name = _queued_packages[1]
   if queued_package_name then
@@ -192,7 +192,7 @@ function vmf.update_package_manager()
 end
 
 
--- Forcefully unloads all not unloaded pacakges.
+-- Forcefully unloads all not unloaded packages.
 function vmf.unload_all_resource_packages()
   for package_name, package_data in pairs(_packages) do
     local package_status = package_data.status

--- a/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
@@ -94,7 +94,7 @@ function VMFMod:load_package(package_name, callback, sync)
     return
   end
 
-  -- If package is_already_queued it means it was already loaded asynchroniously before, but not fully loaded yet.
+  -- If package is_already_queued it means it was already loaded asynchronously before, but not fully loaded yet.
   -- It can have "queued" or "loading" status. Don't redefine data for this package.
   local is_already_queued = _packages[package_name] ~= nil
   if not is_already_queued then

--- a/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
@@ -3,6 +3,13 @@ local vmf = get_mod("VMF")
 local _packages = {}
 local _queued_packages = {}
 
+local PUBLIC_STATUSES = {
+  queued            = "loading", -- Package is in the loading queue waiting to be loaded.
+  loading           = "loading", -- Package is loading.
+  loaded            = "loaded",  -- Package is loaded
+  loading_cancelled = nil        -- Package is loading, but will be unloaded once done loading.
+}
+
 local ERRORS = {
   REGULAR = {
     -- check_vt1:
@@ -179,7 +186,9 @@ function VMFMod:package_status(package_name)
   end
 
   local package_data = _packages[package_name]
-  return package_data and package_data.status
+  if package_data then
+    return PUBLIC_STATUSES[package_data.status]
+  end
 end
 
 -- #####################################################################################################################

--- a/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_package_manager.lua
@@ -54,6 +54,16 @@ local function flush_package(package_name)
   end
 end
 
+
+local function remove_package_from_queue(package_name)
+  for i, queued_package_name in ipairs(_queued_packages) do
+    if package_name == queued_package_name then
+      table.remove(_queued_packages, i)
+      return
+    end
+  end
+end
+
 -- #####################################################################################################################
 -- ##### VMFMod ########################################################################################################
 -- #####################################################################################################################
@@ -101,6 +111,9 @@ function VMFMod:load_package(package_name, callback, sync)
     if _packages[package_name].status == "queued" then
       resource_package:load()
     end
+    if is_already_queued then
+      remove_package_from_queue(package_name)
+    end
     flush_package(package_name)
   else
     if is_already_queued then
@@ -130,12 +143,7 @@ function VMFMod:unload_package(package_name)
   end
 
   if package_status == "queued" then
-    for i, queued_package_name in ipairs(_queued_packages) do
-      if package_name == queued_package_name then
-        table.remove(_queued_packages, i)
-        break
-      end
-    end
+    remove_package_from_queue(package_name)
   elseif package_status == "loading" then
     self:error(ERRORS.REGULAR.cant_unload_loading_package, package_name)
     return


### PR DESCRIPTION
Several days ago @ManuelBlanc and I had a very productive talk about the VMF package manager. This PR is the result of that discussion plus some of my afterthoughts. 

First of all, the inner structure was changed, so all the info about packages is stored inside `_packages` array, which looks approximately like this

```lua
local _packages = {
  ["package/name/one"] = {
    status           = "loaded",
    resource_package = RESOURCE_PACKAGE_USERDATA,
    callback         = callback or nil,
    mod              = MOD_OBJECT
  },
  ["package/name/two"] = {
    status           = "loading",
    resource_package = RESOURCE_PACKAGE_USERDATA,
    callback         = callback or nil,
    mod              = MOD_OBJECT
  },
  ["package/name/three"] = {
    status           = "queued",
    resource_package = RESOURCE_PACKAGE_USERDATA,
    callback         = callback or nil,
    mod              = MOD_OBJECT
  },
  -- [[ ... ]]
}
```

This makes a lot of things simpler and faster. No need to iterate through array tables anymore.

This also brings changes to API. Functions `is_package_loading` and `has_package_loaded` are replaced with one function:


```lua
mod:package_status("path/to/a/package")

-- RETURNS:

nil --  there was no attempt to load this package

"queued" -- queued for loading but not actually loading yet

"loading" -- in the process of loading

"loaded" -- done loading
```

Comparing with the previous implementation for a better picture (before-after):

```lua
-- COMPARISON

if mod:is_package_loading("path/to/a/package") or mod:has_package_loaded("path/to/a/package") then

if mod:package_status("path/to/a/package") then

-- ##################################

if not mod:is_package_loading("path/to/a/package") and not mod:has_package_loaded("path/to/a/package") then

if not mod:package_status("path/to/a/package") then

-- ##################################

if mod:is_package_loading("path/to/a/package") then

if mod:package_status("path/to/a/package") == "queued" or mod:package_status("path/to/a/package") == "loading" then

-- ##################################

if mod:has_package_loaded("path/to/a/package") then

if mod:package_status("path/to/a/package") == "loaded" then
```

Points for implementing it besides speed boost and code readability:

1) A package can only be in one of those mutually exclusive states. Having a predicate for each state is somewhat questionable.
Will both functions return `true` at the same time? Would you have 100 predicates for a state machine with 100 different states? `is_state_machine_in_state55`

2) Having a single function reduces the API surface area. A good rule of thumb is keeping the number of methods at a minimum since it reduces the cognitive load on the programmer
I have to remember if it's `has_package_loaded` or `is_package_loaded` or `is_package_finished_loading`

I also changed 2 things for API:

1) The callback will be executed even for not async packages.

2) If you'll try to unload queued packages, it won't show you an error, but will just remove the package from loading queue. You still can't unload packages that are in process of loading.

Finally, I made a [mod example](https://github.com/Vermintide-Mod-Framework/VMF-Mods-Examples/tree/master/package_management_example) for this new implementation, so you can test it.