### PR TITLE
Subclass hook fix

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -289,6 +289,8 @@ local function generic_hook(mod, obj, method, handler, func_name)
         mod:error("(%s): trying to hook %s (a %s), not a function.", func_name, method, type(orig))
         return
     end
+    
+    -- Edge Case: If someone hooks a copy of a function after its been hooked, point it back in the right direction
     if _registry.uids[orig] then
         orig = _registry.uids[orig]
     end
@@ -327,8 +329,6 @@ local function generic_hook_toggle(mod, obj, method, enabled_state)
             return
         end
     end
-
-    local orig = get_orig_function(obj, method)
 
     if _registry[mod][obj[method]] then
         _registry[mod][obj[method]].active = enabled_state


### PR DESCRIPTION
Alright, this is a pull request fixing a pretty long-standing flaw that I never got back to fix.

Take this example: 
```
local A = { func = function() end }
local B = { func = A.func }
mod:hook(A, "func", ...)
mod:hook(B, "func", ...) --> This will execute A's hook. Bad.
```
The issue was due to the fact that the system was using the original function's reference as a unique identifier for storing hooks. It works in most cases, but sadly whgen it comes to inherited functions/classes, they would be running the same hooks as the parent. 

This PR contains 3 commits as of now:
Commit 1: Remove all the ambiguity between [obj][method] or [method] and force everything to use [obj][method]. Global functions filed under the _G obj. 
Commit 2: Fix the error mentioned above so that hooking B will use its own hooks independant of A.

Commit 3: Attempts to fix an issue brought up by Zaphio of someone copying an already hooked function, which will make it copy our internal hook. This is an highly unorthodox case and I don't know if there's any practical applications, but since it caused both A nd B's hooks to triggers, it definitely needed fixing. 