### PR TITLE
Show Readable Names for Hook Objects in Info Logs.

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -228,8 +228,8 @@ local function create_hook(mod, orig, obj, method, handler, func_name, hook_type
             hook_data.handler = handler
         elseif mod:get_internal_data("allow_rehooking") then
             -- If we can't rehook but rehooking is enabled, send a warning that something went wrong
-            mod:warning("(%s): Attempting to rehook active hook [%s] with different obj or hook_type.", func_name,
-                                                                                                         method)
+            mod:warning("(%s): Attempting to rehook active hook [%s] with different obj or hook_type.",
+                                                                                        func_name, method)
         else
             mod:warning("(%s): Attempting to rehook active hook [%s].", func_name, method)
         end
@@ -291,7 +291,8 @@ local function generic_hook(mod, obj, method, handler, func_name)
 
     -- Quick check to make sure the target exists
     if not obj[method] then
-        mod:error("(%s): trying to hook function or method that doesn't exist: [%s.%s]", func_name, print_obj(obj), method)
+        mod:error("(%s): trying to hook function or method that doesn't exist: [%s.%s]",
+                                                            func_name, print_obj(obj), method)
         return
     end
 

--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -86,6 +86,16 @@ local function can_rehook(mod, hook_data, obj, hook_type)
     end
 end
 
+-- Search global table for an object that matches to get a readable string.
+local function print_obj(obj)
+    for k, v in pairs(_G) do
+        if v == obj then
+            return k
+        end
+    end
+    return obj
+end
+
 -- ####################################################################################################################
 -- ##### Hook Creation ################################################################################################
 -- ####################################################################################################################
@@ -193,7 +203,7 @@ local function create_hook(mod, orig, obj, method, handler, func_name, hook_type
     else
         unique_id = obj[method]
     end
-    mod:info("(%s): Hooking '%s' from [%s] (Origin: %s)", func_name, method, obj, orig)
+    mod:info("(%s): Hooking '%s' from [%s] (Origin: %s)", func_name, method, print_obj(obj), orig)
 
     -- Check to make sure this mod hasn't hooked it before
     local hook_data = _registry[mod][unique_id]
@@ -281,7 +291,7 @@ local function generic_hook(mod, obj, method, handler, func_name)
 
     -- Quick check to make sure the target exists
     if not obj[method] then
-        mod:error("(%s): trying to hook function or method that doesn't exist: [%s.%s]", func_name, obj, method)
+        mod:error("(%s): trying to hook function or method that doesn't exist: [%s.%s]", func_name, print_obj(obj), method)
         return
     end
 

--- a/vmf/scripts/mods/vmf/modules/core/hooks.lua
+++ b/vmf/scripts/mods/vmf/modules/core/hooks.lua
@@ -193,7 +193,7 @@ local function create_hook(mod, orig, obj, method, handler, func_name, hook_type
     else
         unique_id = obj[method]
     end
-    mod:info("(%s): Hooking '%s' from [%s] (Origin: %s) (UniqueID: %s)", func_name, method, obj, orig, unique_id)
+    mod:info("(%s): Hooking '%s' from [%s] (Origin: %s)", func_name, method, obj, orig)
 
     -- Check to make sure this mod hasn't hooked it before
     local hook_data = _registry[mod][unique_id]


### PR DESCRIPTION
Sorry if this is a late addition right before sanctioning, but I finished going through performance testing and its nowhere near as bad as I thought it would be.
Before:
![consolehook](https://user-images.githubusercontent.com/6915139/51452315-9b5c3a00-1d07-11e9-9d14-685ca19d8d39.PNG)
After:
![consolehooksearch](https://user-images.githubusercontent.com/6915139/51452319-a2834800-1d07-11e9-8a0d-8aa4257dcb67.PNG)

This is done by scanning _G to find an matching obj, it stops at the first result found. The performance cost for 150+ hooks is about 3ms, which is rather trivial compared to the benefits.