### PR TITLE
Rewrite the localization module; expand the API

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/options.lua
+++ b/vmf/scripts/mods/vmf/modules/core/options.lua
@@ -100,7 +100,7 @@ local function localize_generic_widget_data(mod, data)
     if data.tooltip then
       data.tooltip = mod:localize(data.tooltip)
     else
-      data.tooltip = vmf.quick_localize(mod, data.setting_id .. "_description")
+      data.tooltip = mod:localize_raw(data.setting_id .. "_description")
     end
   end
 end

--- a/vmf/scripts/mods/vmf/modules/vmf_mod_data.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_mod_data.lua
@@ -48,15 +48,6 @@ end
   Universal function for retrieving any internal mod data. Returned table values shouldn't be modified, because it can
   lead to unexpected VMF behaviour.
   * key [string]: data entry name
-
-  Possible entry names:
-    - name           (system mod name)
-    - readable_name  (readable mod name)
-    - description    (mod description)
-    - is_togglable   (if the mod can be disabled/enabled)
-    - is_enabled     (if the mod is curently enabled)
-    - is_mutator     (if the mod is mutator)
-    - mutator_config (mutator config)
 --]]
 function VMFMod:get_internal_data(key)
   return self._data[key]


### PR DESCRIPTION
## API

```lua
--- Does not format the message; returns nil if the localization is not found.
VMFMod:localize_raw(fully_qualified_text_id)

-- Returns an appropiately qualified text id for this mod that can be used with Localize (eg, in GUIs).
VMFMod:qualify_text_id(text_id) -- namespaces a text id
```

## Observations

All strings are now stored in the same table and made available through the LocalizationManager to the game. By setting `no_prefix` to true, mods are able to replace any game string. If two mods replace the same string, and error will be thrown unless the one that loads last sets `force_override` to override the previous set one.

The localization database now only stores the localized messages for the current locale. At this time, the game requires a restart to change the locale so unused localizations won't take up any memory.

The behaviour of `VMFMod:localize` has changed when the formatting fails for non-English locales. It now returns the a placeholder message instead of trying to format the English localization. This change makes it so `string.format` errors are never masked, so they can be more readily found and fixed.