### PR TITLE
Add .vmbrc file

### DIFF
--- a/.vmbrc
+++ b/.vmbrc
@@ -1,0 +1,29 @@
+{
+	"mods_dir": ".",
+	"temp_dir": ".temp",
+	"game": 2,
+	"game_id1": "235540",
+	"game_id2": "552500",
+	"tools_id1": "718610",
+	"tools_id2": "866060",
+	"fallback_tools_dir1": "C:/Program Files (x86)/Steam/steamapps/common/Warhammer End Times Vermintide Mod Tools/",
+	"fallback_tools_dir2": "C:/Program Files (x86)/Steam/steamapps/common/Vermintide 2 SDK/",
+	"fallback_steamapps_dir1": "C:/Program Files (x86)/Steam/steamapps/",
+	"fallback_steamapps_dir2": "C:/Program Files (x86)/Steam/steamapps/",
+	"use_fallback": false,
+	"copy_source_code": false,
+	"bundle_extension1": "",
+	"bundle_extension2": ".mod_bundle",
+	"use_new_format1": false,
+	"use_new_format2": true,
+	"template_dir": ".template-vmf",
+	"template_preview_image": "item_preview.png",
+	"template_core_files": [
+		"core/**"
+	],
+	"include_dot_files": false,
+	"ignored_dirs": [
+		"assets"
+	],
+	"ignore_build_errors": false
+}


### PR DESCRIPTION
Adding the file allows to run `vmb.exe watch` without providing any arguments on the base VMF dir.

Changes with respect to default .vmbrc file:

+ Set `mods_dir` to `"."` (was `"mods"`).
+ Set `temp_dir` to `".temp"` (was `""`").
+ Set `ignored_dirs` to `[ "assets" ]` (was: `[]`).