### PR TITLE
Adding mutators support

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/events.lua
+++ b/vmf/scripts/mods/vmf/modules/core/events.lua
@@ -119,13 +119,14 @@ end
 
   Is called when a player with the same mod, which uses network, joins the game. Meaning, that this event will be called
   only for mods which registered at least 1 network call.
-  * player [player]: player object of the player who joined the game
+  * player    [player]: player object of the player who joined the game
+  * on_reload [bool]  : 'true' if event is fired after player reloaded his mods in the middle of the game
 --]]
-function vmf.mod_user_joined_the_game(mod, player)
+function vmf.mod_user_joined_the_game(mod, player, on_reload)
 
   local event_name = "on_user_joined"
 
-  run_event(mod, event_name, player)
+  run_event(mod, event_name, player, on_reload)
 end
 
 
@@ -134,13 +135,14 @@ end
 
   Is called when a player with the same mod, which uses network, leaves the game. Meaning, that this event will be
   called only for mods which registered at least 1 network call.
-  * player [player]: player object of the player who is about to leave the game
+  * player    [player]: player object of the player who is about to leave the game
+  * on_reload [bool]  : 'true' if event is fired when player started mod reloading process in the middle of the game
 --]]
-function vmf.mod_user_left_the_game(mod, player)
+function vmf.mod_user_left_the_game(mod, player, on_reload)
 
   local event_name = "on_user_left"
 
-  run_event(mod, event_name, player)
+  run_event(mod, event_name, player, on_reload)
 end
 
 

--- a/vmf/scripts/mods/vmf/modules/core/keybindings.lua
+++ b/vmf/scripts/mods/vmf/modules/core/keybindings.lua
@@ -217,7 +217,7 @@ local function perform_keybind_action(data, is_pressed)
   local can_perform_action = is_vmf_input_service_active() or data.global or data.release_action
 
   if data.type == "mod_toggle" and can_perform_action and not data.mod:get_internal_data("is_mutator") then
-    vmf.mod_state_changed(data.mod:get_name(), not data.mod:is_enabled())
+    vmf.set_mod_state(data.mod, not data.mod:is_enabled())
     return true
   elseif data.type == "function_call" and can_perform_action and data.mod:is_enabled() then
     call_function(data.mod, data.function_name, is_pressed)

--- a/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
@@ -16,11 +16,88 @@ vmf.mutators = {
   --]]
 }
 
+local ERRORS = {
+  THROWABLE = {
+    -- validate_mutator_data:
+    mutator_data_wrong_type = "'mutator_data' must be a table, not %s.",
+    required_on_clients_wrong_type = "'required_on_clients' must be a boolean, not %s.",
+    enable_before_wrong_type = "'enable_before' must be a table, not %s.",
+    enable_before_element_wrong_type = "'enable_before[%s]' must be a string, not %s.",
+    enable_after_wrong_type = "'enable_after' must be a table, not %s.",
+    enable_after_element_wrong_type = "'enable_after[%s]' must be a string, not %s.",
+    dice_wrong_type = "'dice' must be a table, not %s.",
+    dice_missing_field = "'dice' table must contain 'bonus', 'tomes', and 'grims' fields.",
+    dice_field_wrong_type = "'dice.%s' must be a number, not %s.",
+    wrong_dice_number = "'dice.%s' can not be less than 0 and greater than 7.",
+  }
+}
+
+-- =============================================================================
+-- Local functions
+-- =============================================================================
+
+-- [THROWS ERRORS]
+local function validate_mutator_data(data)
+  -- Initial check.
+  if type(data) ~= "table" then
+    vmf.throw_error(ERRORS.THROWABLE.mutator_data_wrong_type, type(data))
+  end
+
+  -- Add missing data.
+  if data.required_on_clients == nil then data.required_on_clients = false                             end
+  if data.enable_before       == nil then data.enable_before       = {}                                end
+  if data.enable_after        == nil then data.enable_after        = {}                                end
+  if data.dice                == nil then data.dice                = {bonus = 0, tomes = 0, grims = 0} end
+
+  -- Other checks.
+  if type(data.required_on_clients) ~= "boolean" then
+    vmf.throw_error(ERRORS.THROWABLE.required_on_clients_wrong_type, type(data.required_on_clients))
+  end
+
+  if type(data.enable_before) ~= "table" then
+    vmf.throw_error(ERRORS.THROWABLE.enable_before_wrong_type, type(data.enable_before))
+  end
+  for i, mutator_name in ipairs(data.enable_before) do
+    if type(mutator_name) ~= "string" then
+      vmf.throw_error(ERRORS.THROWABLE.enable_before_element_wrong_type, i, type(mutator_name))
+    end
+  end
+
+  if type(data.enable_after) ~= "table" then
+    vmf.throw_error(ERRORS.THROWABLE.enable_after_wrong_type, type(data.enable_after))
+  end
+  for i, mutator_name in ipairs(data.enable_after) do
+    if type(mutator_name) ~= "string" then
+      vmf.throw_error(ERRORS.THROWABLE.enable_after_element_wrong_type, i, type(mutator_name))
+    end
+  end
+
+  if type(data.dice) ~= "table" then
+    vmf.throw_error(ERRORS.THROWABLE.dice_wrong_type, type(data.dice))
+  end
+  for _, die_name in ipairs({"bonus", "tomes", "grims"}) do
+    local dice_number = data.dice[die_name]
+    if dice_number == nil then
+      vmf.throw_error(ERRORS.THROWABLE.dice_missing_field)
+    end
+    if type(dice_number) ~= "number" then
+      vmf.throw_error(ERRORS.THROWABLE.dice_field_wrong_type, die_name, type(dice_number))
+    end
+    if dice_number < 0 or dice_number > 7 then
+      vmf.throw_error(ERRORS.THROWABLE.wrong_dice_number, die_name)
+    end
+  end
+end
+
 -- =============================================================================
 -- VMF internal functions
 -- =============================================================================
 
-function vmf.register_mod_as_mutator(mod, raw_config)
+function vmf.initialize_mutator_data(mod, mutator_data)
+  mutator_data = mutator_data or {}
+
+  validate_mutator_data(mutator_data)
+
   vmf.mutators[mod] = {}
 end
 

--- a/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
@@ -23,8 +23,14 @@ local ERRORS = {
     required_on_clients_wrong_type = "'required_on_clients' must be a boolean, not %s.",
     enable_before_wrong_type = "'enable_before' must be a table, not %s.",
     enable_before_element_wrong_type = "'enable_before[%s]' must be a string, not %s.",
+    enable_before_contains_self = "Mutators can't put themselves into 'enable_before' table.",
+    enable_before_duplicate_entry = "Detected duplicate mod name inside 'enable_before' table: '%s'.",
     enable_after_wrong_type = "'enable_after' must be a table, not %s.",
     enable_after_element_wrong_type = "'enable_after[%s]' must be a string, not %s.",
+    enable_after_contains_self = "Mutators can't put themselves into 'enable_after' table.",
+    enable_after_duplicate_entry = "Detected duplicate mod name inside 'enable_after' table: '%s'.",
+    enable_after_contains_enable_before_entry = "Detected the same mod name ('%s') inside both 'enable_after' and " ..
+                                                 "'enable_after' tables.",
     dice_wrong_type = "'dice' must be a table, not %s.",
     dice_missing_field = "'dice' table must contain 'bonus', 'tomes', and 'grims' fields.",
     dice_field_wrong_type = "'dice.%s' must be a number, not %s.",
@@ -37,23 +43,16 @@ local ERRORS = {
 -- =============================================================================
 
 -- [THROWS ERRORS]
-local function validate_mutator_data(data)
-  -- Initial check.
+local function validate_mutator_data(mod, data)
   if type(data) ~= "table" then
     vmf.throw_error(ERRORS.THROWABLE.mutator_data_wrong_type, type(data))
   end
 
-  -- Add missing data.
-  if data.required_on_clients == nil then data.required_on_clients = false                             end
-  if data.enable_before       == nil then data.enable_before       = {}                                end
-  if data.enable_after        == nil then data.enable_after        = {}                                end
-  if data.dice                == nil then data.dice                = {bonus = 0, tomes = 0, grims = 0} end
-
-  -- Other checks.
   if type(data.required_on_clients) ~= "boolean" then
     vmf.throw_error(ERRORS.THROWABLE.required_on_clients_wrong_type, type(data.required_on_clients))
   end
 
+  local mutators_enable_before = {}
   if type(data.enable_before) ~= "table" then
     vmf.throw_error(ERRORS.THROWABLE.enable_before_wrong_type, type(data.enable_before))
   end
@@ -61,8 +60,16 @@ local function validate_mutator_data(data)
     if type(mutator_name) ~= "string" then
       vmf.throw_error(ERRORS.THROWABLE.enable_before_element_wrong_type, i, type(mutator_name))
     end
+    if mutator_name == mod:get_name() then
+      vmf.throw_error(ERRORS.THROWABLE.enable_before_contains_self)
+    end
+    if mutators_enable_before[mutator_name] then
+      vmf.throw_error(ERRORS.THROWABLE.enable_before_duplicate_entry, mutator_name)
+    end
+    mutators_enable_before[mutator_name] = true
   end
 
+  local mutators_enable_after = {}
   if type(data.enable_after) ~= "table" then
     vmf.throw_error(ERRORS.THROWABLE.enable_after_wrong_type, type(data.enable_after))
   end
@@ -70,6 +77,16 @@ local function validate_mutator_data(data)
     if type(mutator_name) ~= "string" then
       vmf.throw_error(ERRORS.THROWABLE.enable_after_element_wrong_type, i, type(mutator_name))
     end
+    if mutator_name == mod:get_name() then
+      vmf.throw_error(ERRORS.THROWABLE.enable_after_contains_self)
+    end
+    if mutators_enable_after[mutator_name] then
+      vmf.throw_error(ERRORS.THROWABLE.enable_after_duplicate_entry, mutator_name)
+    end
+    if mutators_enable_before[mutator_name] then
+      vmf.throw_error(ERRORS.THROWABLE.enable_after_contains_enable_before_entry, mutator_name)
+    end
+    mutators_enable_after[mutator_name] = true
   end
 
   if type(data.dice) ~= "table" then
@@ -93,8 +110,19 @@ end
 -- VMF internal functions
 -- =============================================================================
 
-function vmf.initialize_mutator_data(mod, mutator_data)
-  mutator_data = mutator_data or {}
+-- [THROWS ERRORS]
+function vmf.initialize_mutator_data(mod, data)
+  -- Add optional missing fields before validation.
+  data = data or {}
+  if type(data) == "table" then
+    if data.required_on_clients == nil then data.required_on_clients = false                             end
+    if data.enable_before       == nil then data.enable_before       = {}                                end
+    if data.enable_after        == nil then data.enable_after        = {}                                end
+    if data.dice                == nil then data.dice                = {bonus = 0, tomes = 0, grims = 0} end
+  end
+
+  -- [throws errors]
+  validate_mutator_data(mod, data)
 
   validate_mutator_data(mutator_data)
 

--- a/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
@@ -106,6 +106,26 @@ local function validate_mutator_data(mod, data)
   end
 end
 
+local function sanitize_mutator_data(data)
+  local sanitized_data = {
+    required_on_clients = data.required_on_clients,
+    enable_before       = {},
+    enable_after        = {},
+    dice                = {
+      bonus = data.dice.bonus,
+      tomes = data.dice.tomes,
+      grims = data.dice.grims
+    }
+  }
+  for _, mutator_name in ipairs(data.enable_before) do
+    sanitized_data.enable_before[mutator_name] = true
+  end
+  for _, mutator_name in ipairs(data.enable_after) do
+    sanitized_data.enable_after[mutator_name] = true
+  end
+  return sanitized_data
+end
+
 -- =============================================================================
 -- VMF internal functions
 -- =============================================================================
@@ -124,7 +144,8 @@ function vmf.initialize_mutator_data(mod, data)
   -- [throws errors]
   validate_mutator_data(mod, data)
 
-  validate_mutator_data(mutator_data)
+  local sanitized_data = sanitize_mutator_data(data)
+  vmf.set_internal_data(mod, "mutator_data", sanitized_data)
 
   vmf.mutators[mod] = {}
 end

--- a/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
@@ -5,6 +5,8 @@ local vmf = get_mod("VMF")
 -- v [table]: (required, but can be empty) List of mutators that are dependant
 --            on 'k' mutator and, if enabled, should be disabled in order to
 --            toggle 'k' mutator, and then be enabled again
+-- Used:
+-- * In toggling module to toggle mutators in right order.
 vmf.mutators = {
   --[[
   this_mutator = {

--- a/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/mutator_manager.lua
@@ -1,0 +1,26 @@
+local vmf = get_mod("VMF")
+
+-- Map-like table containing pairs for all mutators.
+-- k [mod]  : Mutator instance
+-- v [table]: (required, but can be empty) List of mutators that are dependant
+--            on 'k' mutator and, if enabled, should be disabled in order to
+--            toggle 'k' mutator, and then be enabled again
+vmf.mutators = {
+  --[[
+  this_mutator = {
+    will_always_be_toggled,
+    only_when_these_two_are_disabled
+  },
+  --]]
+}
+
+-- =============================================================================
+-- VMF internal functions
+-- =============================================================================
+
+function vmf.register_mod_as_mutator(mod, raw_config)
+  vmf.mutators[mod] = {}
+end
+
+function vmf.on_mutator_state_changed(mutator, enabled, initial_call)
+end

--- a/vmf/scripts/mods/vmf/modules/core/mutators/mutators_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/mutators/mutators_manager.lua
@@ -166,7 +166,7 @@ local function disable_impossible_mutators(is_broadcast, reason_text_id)
   for i = #_mutators, 1, -1 do
     local mutator = _mutators[i]
     if mutator:is_enabled() and not mutator_can_be_enabled(mutator) then
-      vmf.mod_state_changed(mutator:get_name(), false)
+      vmf.set_mod_state(mutator, false)
       table.insert(disabled_mutators, mutator)
     end
   end

--- a/vmf/scripts/mods/vmf/modules/core/network/network_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network/network_manager.lua
@@ -1,0 +1,148 @@
+local vmf = get_mod("VMF")
+
+-- @TODO: remove when everything is proven safe
+vmf:pcall(function()
+
+local _INNER_RPC_MANAGER = vmf:dofile("scripts/mods/vmf/modules/core/network/network_rpc_inner")
+local _MODS_RPC_MANAGER  = vmf:dofile("scripts/mods/vmf/modules/core/network/network_rpc_mods")
+
+local ERRORS = {
+  PREFIX = {
+    rpc_sending_failure = "[Network] Sending %s RPC",
+  }
+}
+
+-- =============================================================================
+-- Local functions
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- RPC sending
+-- -----------------------------------------------------------------------------
+
+local function send_rpc_safe(recipient, rpc_type, ...)
+  vmf.safe_call_nr(vmf, {ERRORS.PREFIX.rpc_sending_failure, rpc_type}, vmf.rpc_send, recipient, rpc_type, ...)
+end
+
+
+local function send_rpc_vmf_ping(peer_id)
+  send_rpc_safe(peer_id, "VMF_PING")
+end
+
+
+local function send_rpc_vmf_pong(peer_id, on_reload)
+  local mod_and_rpc_ids = _MODS_RPC_MANAGER.get_own_mod_and_rpc_ids();
+  send_rpc_safe(peer_id, "VMF_PONG", on_reload, mod_and_rpc_ids)
+end
+
+
+local function send_rpc_vmf_reload()
+  send_rpc_safe("others", "VMF_RELOAD")
+end
+
+-- -----------------------------------------------------------------------------
+-- RPC callbacks
+-- -----------------------------------------------------------------------------
+
+local function callback_rpc_ping(peer_id)
+  send_rpc_vmf_pong(peer_id, false)
+end
+
+
+local function callback_rpc_pong(peer_id, on_reload, mod_and_rpc_ids)
+  _INNER_RPC_MANAGER.add_peer(peer_id)
+  _MODS_RPC_MANAGER.add_peer(peer_id, on_reload, mod_and_rpc_ids)
+end
+
+
+local function callback_rpc_reload(peer_id)
+  _INNER_RPC_MANAGER.remove_peer(peer_id)
+  _MODS_RPC_MANAGER.remove_peer(peer_id, true)
+end
+
+
+local function callback_rpc_mod_rpc(...)
+  _MODS_RPC_MANAGER.execute_mod_rpc_callback(...)
+end
+
+-- =============================================================================
+-- Hooks
+-- =============================================================================
+
+vmf:hook(PlayerManager, "add_remote_player", function (func, self, peer_id, player_controlled, ...)
+  if player_controlled then
+    send_rpc_vmf_ping(peer_id)
+  end
+  return func(self, peer_id, player_controlled, ...)
+end)
+
+
+vmf:hook(PlayerManager, "remove_player", function (func, self, peer_id, local_player_id)
+  local player = self:player_from_peer_id(peer_id, local_player_id)
+  if player and not player.bot_player then
+    _INNER_RPC_MANAGER.remove_peer(peer_id)
+    _MODS_RPC_MANAGER.remove_peer(peer_id, false)
+  end
+  return func(self, peer_id, local_player_id)
+end)
+
+-- =============================================================================
+-- VMF internal functions
+-- =============================================================================
+
+function vmf.network_initialize()
+  _INNER_RPC_MANAGER.initialize()
+  _MODS_RPC_MANAGER.initialize()
+
+  -- Sync network data with other VMF users if VMF was reloaded in the middle
+  -- of the game.
+  local player_manager = Managers.player
+  if not player_manager then
+    return
+  end
+
+  -- `Network.peer_id()` throws an error when called at game startup since
+  -- Stingray network module is not yet initialized.
+  if pcall(Network.peer_id) then
+    local local_peer_id = Network.peer_id()
+    for _, player in pairs(player_manager:human_players()) do
+      if player.peer_id ~= local_peer_id then
+        send_rpc_vmf_ping(player.peer_id)
+        send_rpc_vmf_pong(player.peer_id, true)
+      end
+    end
+  end
+end
+
+
+function vmf.network_shutdown()
+  send_rpc_vmf_reload()
+  -- Shutting down inner RPC manager ensures no network communication between
+  -- VMF clients till mods are reloaded. So there's no need to shut down other
+  -- modules.
+  _INNER_RPC_MANAGER.shutdown()
+end
+
+
+function vmf.network_update()
+  -- * update pending clients inside 'network_game_alteration_sync'
+end
+
+
+-- [THROWS ERRORS]
+function vmf.rpc_send(recipient, rpc_type, ...)
+  _INNER_RPC_MANAGER.rpc_send(recipient, rpc_type, ...) -- [throws errors]
+end
+
+-- =============================================================================
+-- Script
+-- =============================================================================
+
+_INNER_RPC_MANAGER.register_inner_rpc_callbacks({
+  VMF_PING   = callback_rpc_ping,
+  VMF_PONG   = callback_rpc_pong,
+  VMF_RELOAD = callback_rpc_reload,
+  MOD_RPC    = callback_rpc_mod_rpc,
+})
+
+end)

--- a/vmf/scripts/mods/vmf/modules/core/network/network_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network/network_manager.lua
@@ -79,7 +79,7 @@ end)
 
 vmf:hook(PlayerManager, "remove_player", function (func, self, peer_id, local_player_id)
   local player = self:player_from_peer_id(peer_id, local_player_id)
-  if player and not player.bot_player then
+  if player and not (player.bot_player or player.local_player) then
     _INNER_RPC_MANAGER.remove_peer(peer_id)
     _MODS_RPC_MANAGER.remove_peer(peer_id, false)
   end

--- a/vmf/scripts/mods/vmf/modules/core/network/network_rpc_inner.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network/network_rpc_inner.lua
@@ -168,7 +168,7 @@ return {
         rpc_other_recipients = _other_peers
       elseif recipient == "others" then
         rpc_other_recipients = _other_peers
-      elseif recipient == "local"then
+      elseif recipient == "local" then
         rpc_send_locally = true
       else
         rpc_other_recipients = {[recipient] = true}

--- a/vmf/scripts/mods/vmf/modules/core/network/network_rpc_inner.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network/network_rpc_inner.lua
@@ -1,0 +1,195 @@
+local vmf = get_mod("VMF")
+
+-- VMF inner RPC implementation is based on Vermintide chat message RPC which
+-- has `channel_id` argument. If this argument is not equal '1', this RPC
+-- is ignored by the game which is perfect for implementing custom RPC behavior
+-- for different channels.
+-- Reserverd channels:
+-- [1] - Vermintide chat channel
+-- [2] - Old-VMF / QoL rpc channel in VT1
+local INNER_RPC_DICTIONARY = {
+  [3] = "VMF_PING",   -- Request for VMF data [Plus check if VMF user]
+  [4] = "VMF_PONG",   -- Response with VMF data [Is indeed VMF user]
+  [5] = "VMF_RELOAD",
+  [6] = "MOD_RPC",    -- Custom mod RPC with serialized arguments
+  [7] = "MOD_TOGGLE",
+
+  VMF_PING   = 3,
+  VMF_PONG   = 4,
+  VMF_RELOAD = 5,
+  MOD_RPC    = 6,
+  MOD_TOGGLE = 7,
+}
+
+-- Callback functions for different VMF inner RPCs.
+-- Callbacks have to be safe to execute.
+local INNER_RPC_CALLBACKS
+
+-- peer_ids of other VMF clients who successfully exchanged their VMF network
+-- data with local client.
+local _other_peers = {}
+
+local _module_is_initialized = false
+
+local ERRORS = {
+  THROWABLE = {
+    serialization_failure = "RPC data serialization failed. %s",
+    local_rpc_execution_failure = "local RPC execution failed. %s",
+    rpc_sending_failure = "failed sending %s to '%s'. %s. Inspect logs for more info.",
+  }
+}
+
+local WARNINGS = {
+  incoming_rpc_when_not_initialized = "[Network] Received inner VMF RPC '%s' from peer %s while Inner RPC module is " ..
+                                       "inactive. Ignoring it.",
+}
+
+-- =============================================================================
+-- Local functions
+-- =============================================================================
+
+-- [THROWS ERRORS]
+local function serialize_data(...)
+  local success, result = pcall(cjson.encode, {...})
+  if success then
+    return cjson.encode({...})
+  else
+    vmf.throw_error(ERRORS.THROWABLE.serialization_failure, result)
+  end
+end
+
+
+-- It is assumed that this function always gets correct serialized data
+-- and never throws errors.
+local function deserialize_data(data)
+  return unpack(cjson.decode(data))
+end
+
+
+-- [THROWS ERRORS]
+local function send_rpc(peer_id, rpc_id, rpc_data)
+  local success, error
+  if VT1 then
+    success, error = pcall(RPC.rpc_chat_message, peer_id, rpc_id, "", rpc_data, "", true, true, true)
+  else
+    success, error = pcall(RPC.rpc_chat_message, peer_id, rpc_id, "", 0, rpc_data, {}, true, true, true, true, true)
+  end
+  if not success then
+    vmf:dump(deserialize_data(rpc_data), "RPC DATA", 3)
+    vmf.throw_error(ERRORS.THROWABLE.rpc_sending_failure, INNER_RPC_DICTIONARY[rpc_id], peer_id, error)
+  end
+end
+
+
+-- [THROWS ERRORS]
+-- '...' is used instead of 'rpc_data' to skip serialization-deserialization
+-- step which is not necessary for local RPCs.
+local function send_rpc_local(rpc_type, ...)
+  -- @TODO: Remove pcall, error message, [T...] when everything is proven safe.
+  local success, error = pcall(INNER_RPC_CALLBACKS[rpc_type], "local", ...)
+  if not success then
+    vmf.throw_error(ERRORS.THROWABLE.local_rpc_execution_failure, error)
+  end
+end
+
+-- =============================================================================
+-- Hooks
+-- =============================================================================
+
+vmf:hook("ChatManager", "rpc_chat_message", function(func, self, sender, channel_id, message_sender, arg1, arg2, ...)
+  -- Channel IDs 3-16 are reserverd for VMF needs.
+  if channel_id < 3 or channel_id > 16 then
+    return func(self, sender, channel_id, message_sender, arg1, arg2, ...)
+  end
+
+  if not _module_is_initialized then
+    vmf:warning(WARNINGS.incoming_rpc_when_not_initialized, INNER_RPC_DICTIONARY[channel_id], sender)
+    return
+  end
+
+  local rpc_data     = VT1 and arg1 or arg2
+  local rpc_type     = INNER_RPC_DICTIONARY[channel_id]
+  local rpc_callback = INNER_RPC_CALLBACKS[rpc_type]
+
+  if rpc_callback then
+    -- @TODO: Remove pcall when everything is proven safe.
+    vmf:pcall(function()
+      rpc_callback(sender, deserialize_data(rpc_data))
+    end)
+  end
+end)
+
+-- =============================================================================
+-- Return
+-- =============================================================================
+
+return {
+  initialize = function()
+    _module_is_initialized = true
+  end,
+  shutdown = function()
+    _module_is_initialized = false
+  end,
+
+
+  register_inner_rpc_callbacks = function(callbacks)
+    INNER_RPC_CALLBACKS = callbacks
+  end,
+
+
+  add_peer = function(peer_id)
+    _other_peers[peer_id] = true
+    vmf:info("Added %s to the VMF users list.", peer_id)
+  end,
+  remove_peer = function(peer_id)
+    _other_peers[peer_id] = nil
+    vmf:info("Removed %s from the VMF users list.", peer_id)
+  end,
+
+  -- [THROWS ERRORS]
+  -- Allowed 'recipient' values:
+  -- * string: "all", "others", "local", peer_id
+  -- * table: {["local"] = true, [peer_id1] = true, [peer_id2] = true, ...}
+  -- It is assumed that 'recipient' is always correct. If 'recipient' is a table:
+  -- * It should not contain local peer_id. (string "local" should be used instead)
+  -- * All peer_ids should be valid (existing).
+  -- * 'false' should not be used for values. It's either 'true' or 'nil'.
+  rpc_send = function(recipient, rpc_type, ...)
+    local rpc_send_locally
+    local rpc_other_recipients
+
+    -- recipient == "all"/"others"/"local"/peer_id
+    if type(recipient) == "string" then
+      if recipient == "all" then
+        rpc_send_locally = true
+        rpc_other_recipients = _other_peers
+      elseif recipient == "others" then
+        rpc_other_recipients = _other_peers
+      elseif recipient == "local"then
+        rpc_send_locally = true
+      else
+        rpc_other_recipients = {[recipient] = true}
+      end
+
+    -- recipient == {peer_id1 = true, peer_id2 = true, ...}
+    else
+      if recipient["local"] then
+        recipient["local"] = nil
+        rpc_send_locally = true
+      end
+      rpc_other_recipients = recipient
+    end
+
+    if rpc_send_locally then
+      send_rpc_local(rpc_type, ...) -- [throws errors]
+    end
+
+    if next(rpc_other_recipients) then
+      local rpc_id   = INNER_RPC_DICTIONARY[rpc_type]
+      local rpc_data = serialize_data(...) -- [throws errors]
+      for peer_id in pairs(rpc_other_recipients) do
+        send_rpc(peer_id, rpc_id, rpc_data) -- [throws errors]
+      end
+    end
+  end
+}

--- a/vmf/scripts/mods/vmf/modules/core/network/network_rpc_inner.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network/network_rpc_inner.lua
@@ -25,6 +25,9 @@ local INNER_RPC_DICTIONARY = {
 -- Callbacks have to be safe to execute.
 local INNER_RPC_CALLBACKS
 
+-- Steam user ID == peer_id. Cache it to avoid extra calls.
+local LOCAL_PEER_ID = Steam.user_id()
+
 -- peer_ids of other VMF clients who successfully exchanged their VMF network
 -- data with local client.
 local _other_peers = {}
@@ -86,7 +89,7 @@ end
 -- step which is not necessary for local RPCs.
 local function send_rpc_local(rpc_type, ...)
   -- @TODO: Remove pcall, error message, [T...] when everything is proven safe.
-  local success, error = pcall(INNER_RPC_CALLBACKS[rpc_type], "local", ...)
+  local success, error = pcall(INNER_RPC_CALLBACKS[rpc_type], LOCAL_PEER_ID, ...)
   if not success then
     vmf.throw_error(ERRORS.THROWABLE.local_rpc_execution_failure, error)
   end

--- a/vmf/scripts/mods/vmf/modules/core/network/network_rpc_mods.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network/network_rpc_mods.lua
@@ -1,0 +1,300 @@
+local vmf = get_mod("VMF")
+
+-- Table for storing mod RPC callbacks. Is used for:
+-- * Safety checks.
+-- * Generating encode/decode dictionaries.
+local _rpc_callbacks = {}
+--    _rpc_callbacks[mod][rpc_name] = rpc_callback
+
+-- Instead of sending plain mod name and RPC name to clients every time some RPC
+-- needs to be executed, this module uses pair of short unique numbers (IDs)
+-- for RPC identification. These IDs are generated once all mods are loaded and
+-- do not change unless VMF is reloaded. It is done to save bandwidth.
+-- Initially, only mod name was used as a mod unique identifier, but it could
+-- lead to weird collisions if 2 VMF clients had 2 different mods with the same
+-- name so it was decided to use workshop_id as well.
+-- Generated IDs are unique and will differ for every VMF client so they have
+-- to be exchanged between clients to be able to communicate with each other.
+local _own_mod_and_rpc_ids
+--    _own_mod_and_rpc_ids.mod_ids[mod_id] = {mod_name, mod_workshop_id}
+--    _own_mod_and_rpc_ids.rpc_ids[mod_id][rpc_id] = rpc_name
+
+-- Dictionaries are used to quickly replace outgoing RPCs info with the pair of
+-- short IDs (encode dictionary) and to quickly retrieve original RPC info for
+-- incoming RPCs (decode dictionary).
+-- * Encode dictionary is generated only locally to encode all outgoing RPCs.
+-- * Decode dictionary is generated for every VMF user once they send their IDs
+--   to decode incoming RPCs.
+-- * Decode dictionary identifier for VMF peers is their peer_id except for
+--   local player, which uses string "local" as their identifier.
+local _rpc_encode_dictionary
+--    _rpc_encode_dictionary[mod][rpc_name] = {mod_id, rpc_id}
+local _rpc_decode_dictionaries = {}
+--    _rpc_decode_dictionaries[peer_id][mod_id][rpc_id] = {mod=, name=, callback=}
+
+-- Keeps track of users of every network mod, excluding local player.
+local _mods_users_list = {}
+--    _mods_users_list[mod][peer_id] = true
+
+local _module_is_initialized = false
+
+local ERRORS = {
+  REGULAR = {
+    rpc_registering_too_late = "[Network] (network_register) '%s': RPCs can not be registered after all mods " ..
+                                "are initialized.",
+    rpc_registering_duplicate = "[Network] (network_register) '%s': RPC with the same name is already registered.",
+    rpc_sending_too_early = "[Network] (network_send) '%s': RPCs can not be sent until all mods are loaded.",
+    non_registered_rpc = "[Network] (network_send): attempt to send non-registered RPC '%s'.",
+    incorrect_peer_id = "[Network] (network_send) '%s': attempt to send RPC to the player with peer_id '%s'" ..
+                         "who does not have this mod installed.",
+  },
+  PREFIX = {
+    sending_mod_rpc = "[Network] (network_send) Sending '%s' RPC to '%s'",
+    executing_rpc_callback = "[Network] Executing '%s' RPC callback sent by '%s'"
+  }
+}
+
+-- =============================================================================
+-- Local functions
+-- =============================================================================
+
+local function is_rpc_registered(mod, rpc_name)
+  local mod_callbacks = _rpc_callbacks[mod]
+  return mod_callbacks and mod_callbacks[rpc_name]
+end
+
+
+local function generate_own_mod_and_rpc_ids()
+  local mod_ids = {}
+  local rpc_ids = {}
+
+  local mod_id = 0
+  for mod, mod_rpcs_data in pairs(_rpc_callbacks) do
+    mod_id = mod_id + 1
+
+    mod_ids[mod_id] = {mod:get_name(), mod:get_internal_data("workshop_id")}
+    rpc_ids[mod_id] = {}
+
+    local rpc_id = 0
+    for rpc_name in pairs(mod_rpcs_data) do
+      rpc_id = rpc_id + 1
+
+      rpc_ids[mod_id][rpc_id] = rpc_name
+    end
+  end
+
+  _own_mod_and_rpc_ids = {
+    mod_ids = mod_ids,
+    rpc_ids = rpc_ids
+  }
+end
+
+
+-- * Generate encode and decode dictionaries for provided peer_id based on their
+--   mod and rpc IDs.
+--   - After generation is done, save dictionaries. Encode dictionary is saved
+--   only for local player.
+--   - Entries inside dictionaries are created only for locally existing mods.
+-- * Populate `_mods_users_list`.
+-- * Fire 'mod.on_user_joined' event for all locally existing mods if peer_id is
+--   not local.
+local function initialize_peer(peer_id, mod_and_rpc_ids, on_reload)
+  local is_local_peer_id = peer_id == "local"
+
+  local mod_ids = mod_and_rpc_ids.mod_ids
+  local rpc_ids = mod_and_rpc_ids.rpc_ids
+
+  local encode_dictionary = {}
+  local decode_dictionary = {}
+
+  -- Populate dictionaries and `_mods_users_list`.
+  for mod_id, mod_data in ipairs(mod_ids) do
+    local mod = get_mod(mod_data[1])
+    -- Make sure this mod exists locally and this is the exact same mod.
+    -- And only then create entry in dictionaries.
+    if mod and mod:get_internal_data("workshop_id") == mod_data[2] then
+      if not is_local_peer_id then
+        _mods_users_list[mod][peer_id] = true
+      end
+
+      encode_dictionary[mod]    = {}
+      decode_dictionary[mod_id] = {}
+      for rpc_id, rpc_name in ipairs(rpc_ids[mod_id]) do
+        encode_dictionary[mod][rpc_name]  = {mod_id, rpc_id}
+        decode_dictionary[mod_id][rpc_id] = {mod = mod, name = rpc_name, callback = _rpc_callbacks[mod][rpc_name]}
+      end
+    end
+  end
+
+  -- Save generated decode dictionary.
+  _rpc_decode_dictionaries[peer_id] = decode_dictionary
+  -- Save generated encode dictionary, but only for local player.
+  if is_local_peer_id then
+    _rpc_encode_dictionary = encode_dictionary
+  -- Fire 'mod.on_user_joined' events for all mods remote and local players
+  -- have in common.
+  else
+    local player = Managers.player:player_from_peer_id(peer_id)
+    for mod, mod_users in pairs(_mods_users_list) do
+      if mod_users[peer_id] then
+        vmf.mod_user_joined_the_game(mod, player, on_reload)
+      end
+    end
+  end
+end
+
+
+-- * Delete decode dictionary for given peer_id.
+-- * Remove all `_mods_users_list` entries for this peer_id and fire
+--   `mod.on_user_left` event for all the mods they had.
+-- This function is never called for local player, because local player's
+-- generated ids are persistent.
+local function remove_peer(peer_id, on_reload)
+  _rpc_decode_dictionaries[peer_id] = nil
+  local player = Managers.player:player_from_peer_id(peer_id)
+  for mod, mod_users in pairs(_mods_users_list) do
+    if mod_users[peer_id] then
+      mod_users[peer_id] = nil
+      vmf.mod_user_left_the_game(mod, player, on_reload)
+    end
+  end
+end
+
+-- ============================================================================
+-- VMFMod
+-- ============================================================================
+
+-- Register a new remote procedure call.
+-- * rpc_name     [string]  : RPC name
+-- * rpc_callback [function]: RPC callback
+function VMFMod:network_register(rpc_name, rpc_callback)
+  if vmf.check_wrong_argument_type(self, "network_register", "rpc_name", rpc_name, "string")
+  or vmf.check_wrong_argument_type(self, "network_register", "rpc_callback", rpc_callback, "function")
+  then return end
+
+  if _module_is_initialized then
+    self:error(ERRORS.REGULAR.rpc_registering_too_late, rpc_name)
+    return
+  end
+
+  _rpc_callbacks[self] = _rpc_callbacks[self] or {}
+  if _rpc_callbacks[self][rpc_name] then
+    self:error(ERRORS.REGULAR.rpc_registering_duplicate, rpc_name)
+  else
+    _rpc_callbacks[self][rpc_name] = rpc_callback
+    if not _mods_users_list[self] then
+      _mods_users_list[self] = {}
+    end
+  end
+end
+
+
+-- Execute a remote procedure call locally or on a remote peer.
+-- * rpc_name  [string]          : RPC name
+-- * recipient [string/peer_id]  : RPC recipient; valid values: "all", "local", "others", peer_id
+-- * ...       [any serializable]: Serializable RPC arguments
+function VMFMod:network_send(rpc_name, recipient, ...)
+  if not _module_is_initialized then
+    self:error(ERRORS.REGULAR.rpc_sending_too_early, rpc_name)
+    return
+  end
+
+  if not is_rpc_registered(self, rpc_name) then
+    self:error(ERRORS.REGULAR.non_registered_rpc, rpc_name)
+    return
+  end
+
+  local recipient_original = recipient
+
+  if recipient == "all" then
+    recipient = table.clone(_mods_users_list[self])
+    recipient["local"] = true
+  elseif recipient == "others" then
+    recipient = table.clone(_mods_users_list[self])
+  elseif recipient == "local" or recipient == Network.peer_id() then
+    recipient = {["local"] = true}
+  elseif _mods_users_list[self][recipient] then
+    recipient = {[recipient] = true}
+  else
+    self:error(ERRORS.REGULAR.incorrect_peer_id, rpc_name, recipient)
+    return
+  end
+
+  local mod_id, rpc_id = unpack(_rpc_encode_dictionary[self][rpc_name])
+  vmf.safe_call_nr(self, {ERRORS.PREFIX.sending_mod_rpc, rpc_name, recipient_original},
+                          vmf.rpc_send, recipient, "MOD_RPC", mod_id, rpc_id, {...})
+end
+
+
+-- Returns an array-like table containing peer_ids of all currently connected
+-- mod users excluding local user. Returns nil, if called by a non-network mod.
+function VMFMod:get_connections()
+  if _mods_users_list[self] then
+    local mod_users = {}
+    for peer_id in pairs(_mods_users_list[self]) do
+      table.insert(mod_users, peer_id)
+    end
+    return mod_users
+  end
+end
+
+
+-- Returns a boolean value indicating if the player with passed peer_id has
+-- this mod installed and is connected. Returns nil, if called by a non-network
+-- mod.
+function VMFMod:is_connected(peer_id)
+  if _mods_users_list[self] then
+    return not not _mods_users_list[self][peer_id]
+  end
+end
+
+-- ============================================================================
+-- Return
+-- ============================================================================
+
+return {
+  initialize = function()
+    generate_own_mod_and_rpc_ids()
+    initialize_peer("local", _own_mod_and_rpc_ids)
+    _module_is_initialized = true
+  end,
+
+
+  add_peer = function(peer_id, on_reload, mod_and_rpc_ids)
+    initialize_peer(peer_id, mod_and_rpc_ids, on_reload)
+  end,
+
+
+  remove_peer = function(peer_id, on_reload)
+    remove_peer(peer_id, on_reload)
+  end,
+
+
+  get_own_mod_and_rpc_ids = function()
+    return _own_mod_and_rpc_ids
+  end,
+
+
+  -- Executes RPC callback for recieved mod RPC. It is assumed that IDs and
+  -- RPC data are always valid.
+  execute_mod_rpc_callback = function(sender, mod_id, rpc_id, rpc_data)
+    local args_number = #rpc_data
+    -- When serializing array-like tables `cjson` module replaces nils with
+    -- `userdata [nullptr (deleted)]`. Change it back to nil. It makes sense
+    -- to do this only for the top level of received table which stores packed
+    -- arguments. Going deeper could be pretty costly so it's on the modder to
+    -- avoid nils in array-like tables or to correctly detect userdata fields.
+    for i, v in ipairs(rpc_data) do
+      if type(v) == "userdata" then
+        rpc_data[i] = nil
+      end
+    end
+
+    local rpc_info     = _rpc_decode_dictionaries[sender][mod_id][rpc_id]
+    local mod          = rpc_info.mod
+    local rpc_name     = rpc_info.name
+    local rpc_callback = rpc_info.callback
+    vmf.safe_call_nr(mod, {ERRORS.PREFIX.executing_rpc_callback, rpc_name, sender},
+                           rpc_callback, sender, unpack(rpc_data, 1, args_number))
+  end,
+}

--- a/vmf/scripts/mods/vmf/modules/core/toggling.lua
+++ b/vmf/scripts/mods/vmf/modules/core/toggling.lua
@@ -30,11 +30,7 @@ local function set_mod_state(mod, is_enabled, initial_call)
     if mod:get_internal_data("is_mutator") then
       _enabled_mutators[mod:get_name()] = is_enabled
     else
-      if is_enabled then
-        _disabled_mods[mod:get_name()] = nil
-      else
-        _disabled_mods[mod:get_name()] = true
-      end
+      _disabled_mods[mod:get_name()] = not is_enabled or nil
       vmf:set("disabled_mods_list", _disabled_mods)
     end
   end
@@ -82,11 +78,7 @@ end
 function vmf.initialize_mod_state(mod)
   local state
   if mod:get_internal_data("is_mutator") then
-    if _enabled_mutators[mod:get_name()] then
-      state = true
-    else
-      state = false
-    end
+    state = not not _enabled_mutators[mod:get_name()]
     set_mutator_state(mod, state, true)
   else
     state = not _disabled_mods[mod:get_name()]

--- a/vmf/scripts/mods/vmf/modules/core/toggling.lua
+++ b/vmf/scripts/mods/vmf/modules/core/toggling.lua
@@ -76,13 +76,17 @@ end
 -- * All mutators are disabled by default unless they were enabled before
 --   VMF reloading.
 function vmf.initialize_mod_state(mod)
-  local state
-  if mod:get_internal_data("is_mutator") then
-    state = not not _enabled_mutators[mod:get_name()]
-    set_mutator_state(mod, state, true)
+  if mod:get_internal_data("is_togglable") then
+    local state
+    if mod:get_internal_data("is_mutator") then
+      state = not not _enabled_mutators[mod:get_name()]
+      set_mutator_state(mod, state, true)
+    else
+      state = not _disabled_mods[mod:get_name()]
+      set_mod_state(mod, state, true)
+    end
   else
-    state = not _disabled_mods[mod:get_name()]
-    set_mod_state(mod, state, true)
+    vmf.set_internal_data(mod, "is_enabled", true)
   end
 end
 

--- a/vmf/scripts/mods/vmf/modules/core/toggling.lua
+++ b/vmf/scripts/mods/vmf/modules/core/toggling.lua
@@ -1,13 +1,21 @@
 local vmf = get_mod("VMF")
 
+-- Keeps track of disabled non-mutator mods to carry their state between game
+-- sessions and VMF reloads.
 local _disabled_mods = vmf:get("disabled_mods_list") or {}
 
--- ####################################################################################################################
--- ##### VMF internal functions and variables #########################################################################
--- ####################################################################################################################
+-- List of enabled mutators to carry their state between VMF reloads.
+local _enabled_mutators = vmf:persistent_table("enabled_mutators")
 
-vmf.set_mod_state = function (mod, is_enabled, initial_call)
+-- =============================================================================
+-- Local functions
+-- =============================================================================
 
+-- * Sets mod's state.
+-- * Enables/disables all mod hooks depending on mod state.
+-- * Calls `on_enabled`/`on_disabled` events.
+-- * Keeps track of disabled mods and enabled mutators.
+local function set_mod_state(mod, is_enabled, initial_call)
   vmf.set_internal_data(mod, "is_enabled", is_enabled)
 
   if is_enabled then
@@ -18,45 +26,83 @@ vmf.set_mod_state = function (mod, is_enabled, initial_call)
     vmf.mod_disabled_event(mod, initial_call)
   end
 
-  if not (initial_call or mod:get_internal_data("is_mutator")) then
-    if is_enabled then
-      _disabled_mods[mod:get_name()] = nil
+  if not initial_call then
+    if mod:get_internal_data("is_mutator") then
+      _enabled_mutators[mod:get_name()] = is_enabled
     else
-      _disabled_mods[mod:get_name()] = true
+      if is_enabled then
+        _disabled_mods[mod:get_name()] = nil
+      else
+        _disabled_mods[mod:get_name()] = true
+      end
+      vmf:set("disabled_mods_list", _disabled_mods)
     end
-    vmf:set("disabled_mods_list", _disabled_mods)
   end
 end
 
--- Called when mod is loaded for the first time using mod:initialize()
-vmf.initialize_mod_state = function (mod)
+-- A fancy `set_mod_state` wrapper for mutators.
+-- * Ensures correct toggling order.
+-- * Notifies mutator module about mutator's changed state.
+-- Correct toggling order is ensured only after all mods are initialized.
+-- Otherwise, launcher's order is used.
+local function set_mutator_state(mutator, is_enabled, initial_call)
+  local disabled_mutators = {}
 
+  -- Disable all enabled dependant mutators.
+  if not initial_call then
+    for _, dependant_mutator in ipairs(vmf.mutators[mutator]) do
+      if dependant_mutator:is_enabled() then
+        set_mutator_state(dependant_mutator, false, false)
+        table.insert(disabled_mutators, dependant_mutator)
+      end
+    end
+  end
+
+  -- Toggle current mutator state.
+  set_mod_state(mutator, is_enabled, initial_call)
+  vmf.on_mutator_state_changed(mutator, is_enabled, initial_call)
+
+  -- Re-enable disabled mutators.
+  if not initial_call then
+    for _, disabled_mutator in ipairs(disabled_mutators) do
+      set_mutator_state(disabled_mutator, true, false)
+    end
+  end
+end
+
+-- =============================================================================
+-- VMF internal functions
+-- =============================================================================
+
+-- Sets mod's state for the first time.
+-- * Called for all togglable mods and mutators when they finish their
+--   initialization process.
+-- * All mutators are disabled by default unless they were enabled before
+--   VMF reloading.
+function vmf.initialize_mod_state(mod)
   local state
   if mod:get_internal_data("is_mutator") then
-    -- if VMF was reloaded and mutator was activated
-    if vmf.is_mutator_enabled(mod:get_name()) then
+    if _enabled_mutators[mod:get_name()] then
       state = true
     else
       state = false
     end
-    vmf.set_mutator_state(mod, state, true)
+    set_mutator_state(mod, state, true)
   else
     state = not _disabled_mods[mod:get_name()]
-    vmf.set_mod_state(mod, state, true)
+    set_mod_state(mod, state, true)
   end
 end
 
-vmf.mod_state_changed = function (mod_name, is_enabled)
-
-  local mod = get_mod(mod_name)
-
+-- Sets mod's state if safety checks were successful.
+function vmf.set_mod_state(mod, is_enabled)
   if not mod:get_internal_data("is_togglable") or is_enabled == mod:is_enabled() then
     return
   end
 
   if mod:get_internal_data("is_mutator") then
-    vmf.set_mutator_state(mod, is_enabled, false)
+    set_mutator_state(mod, is_enabled, false)
   else
-    vmf.set_mod_state(mod, is_enabled, false)
+    set_mod_state(mod, is_enabled, false)
   end
 end

--- a/vmf/scripts/mods/vmf/modules/ui/mutators/mutators_gui.lua
+++ b/vmf/scripts/mods/vmf/modules/ui/mutators/mutators_gui.lua
@@ -143,9 +143,9 @@ local function offset_function_callback(ui_scenegraph_, style, content, ui_rende
   -- Enable/disable mutator.
   if content.highlight_hotspot.on_release then
     if mutator:is_enabled() then
-      vmf.mod_state_changed(mutator:get_name(), false)
+      vmf.set_mod_state(mutator, false)
     elseif can_be_enabled then
-      vmf.mod_state_changed(mutator:get_name(), true)
+      vmf.set_mod_state(mutator, true)
     end
   end
 

--- a/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
+++ b/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
@@ -3060,7 +3060,7 @@ end
 
 VMFOptionsView.callback_mod_state_changed = function (self, mod_name, is_mod_enabled)
 
-  vmf.mod_state_changed(mod_name, is_mod_enabled)
+  vmf.set_mod_state(get_mod(mod_name), is_mod_enabled)
 
   WwiseWorld.trigger_event(self.wwise_world, "Play_hud_select")
 

--- a/vmf/scripts/mods/vmf/modules/vmf_mod_data.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_mod_data.lua
@@ -27,7 +27,6 @@ function VMFMod:init(mod_name)
   })
   set_internal_data(self, "name",          mod_name)
   set_internal_data(self, "readable_name", mod_name)
-  set_internal_data(self, "is_enabled",    true)
   set_internal_data(self, "is_togglable",  false)
   set_internal_data(self, "is_mutator",    false)
 

--- a/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
@@ -56,7 +56,7 @@ local function resolve_resource(mod, error_prefix_data, resource, resource_value
   elseif type_value == "function" then
     return vmf.safe_call(mod, error_prefix_data, resource_value, mod)
   elseif type_value == "table" then
-    return true, type_value
+    return true, resource_value
   end
 
   mod:warning("%s: 'mod_%s' (optional) should be a string, function or table; not %s",

--- a/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_mod_manager.lua
@@ -126,9 +126,7 @@ function new_mod(mod_name, mod_resources)
   end
 
   -- Initialize mod state
-  if mod:get_internal_data("is_togglable") then
-    vmf.initialize_mod_state(mod)
-  end
+  vmf.initialize_mod_state(mod)
 
   return mod
 end
@@ -143,6 +141,8 @@ end
 -- #####################################################################################################################
 
 vmf = create_mod("VMF")
+-- Toggling module is not yet initialized so set "is_enabled" directly.
+vmf.set_internal_data(vmf, "is_enabled", true)
 
 -- #####################################################################################################################
 -- ##### VMF internal functions and variables ##########################################################################

--- a/vmf/scripts/mods/vmf/modules/vmf_options.lua
+++ b/vmf/scripts/mods/vmf/modules/vmf_options.lua
@@ -185,7 +185,7 @@ vmf.on_setting_changed = function (setting_id)
 
   elseif setting_id == "show_network_debug_info" then
 
-    vmf.load_network_settings()
+    --vmf.load_network_settings()
 
   elseif setting_id == "log_ui_renderers_info" then
 

--- a/vmf/scripts/mods/vmf/vmf_loader.lua
+++ b/vmf/scripts/mods/vmf/vmf_loader.lua
@@ -71,6 +71,7 @@ function vmf_mod_object:update(dt)
 
     --if VT1 then vmf.modify_map_view() end
     --if VT1 then vmf.mutators_delete_raw_config() end
+    vmf.initialize_correct_mutators_toggling_order()
 
     vmf.all_mods_loaded_event()
 

--- a/vmf/scripts/mods/vmf/vmf_loader.lua
+++ b/vmf/scripts/mods/vmf/vmf_loader.lua
@@ -29,7 +29,7 @@ function vmf_mod_object:init()
   dofile("scripts/mods/vmf/modules/core/localization")
   dofile("scripts/mods/vmf/modules/core/options")
   dofile("scripts/mods/vmf/modules/legacy/options")
-  dofile("scripts/mods/vmf/modules/core/network")
+  dofile("scripts/mods/vmf/modules/core/network/network_manager")
   dofile("scripts/mods/vmf/modules/core/commands")
   dofile("scripts/mods/vmf/modules/gui/custom_textures")
   dofile("scripts/mods/vmf/modules/gui/custom_views")
@@ -57,6 +57,7 @@ end
 
 function vmf_mod_object:update(dt)
   vmf.update_package_manager()
+  vmf.network_update()
   vmf.mods_update_event(dt)
   vmf.check_keybinds()
   vmf.execute_queued_chat_command()
@@ -66,9 +67,10 @@ function vmf_mod_object:update(dt)
 
     vmf.generate_keybinds()
     vmf.initialize_vmf_options_view()
-    vmf.create_network_dictionary()
-    vmf.ping_vmf_users()
+    --vmf.create_network_dictionary()
+    --vmf.ping_vmf_users()
 
+    vmf.network_initialize()
     --if VT1 then vmf.modify_map_view() end
     --if VT1 then vmf.mutators_delete_raw_config() end
     vmf.initialize_correct_mutators_toggling_order()
@@ -92,6 +94,7 @@ function vmf_mod_object:on_reload()
   vmf.disable_mods_options_button()
   if VT1 then vmf.reset_map_view() end
   vmf.mods_unload_event(false)
+  vmf.network_shutdown()
   vmf.remove_custom_views()
   vmf.unload_all_resource_packages()
   vmf.hooks_unload()

--- a/vmf/scripts/mods/vmf/vmf_loader.lua
+++ b/vmf/scripts/mods/vmf/vmf_loader.lua
@@ -37,10 +37,10 @@ function vmf_mod_object:init()
   dofile("scripts/mods/vmf/modules/ui/options/mod_options")
   dofile("scripts/mods/vmf/modules/vmf_options")
 
-  if VT1 then
-    dofile("scripts/mods/vmf/modules/core/mutators/mutators_manager")
-    dofile("scripts/mods/vmf/modules/ui/mutators/mutators_gui")
-  end
+  -- if VT1 then
+  --   dofile("scripts/mods/vmf/modules/core/mutators/mutators_manager")
+  --   dofile("scripts/mods/vmf/modules/ui/mutators/mutators_gui")
+  -- end
 
   vmf = get_mod("VMF")
   vmf.delayed_chat_messages_hook()
@@ -59,7 +59,7 @@ function vmf_mod_object:update(dt)
   vmf.mods_update_event(dt)
   vmf.check_keybinds()
   vmf.execute_queued_chat_command()
-  if VT1 then vmf.check_mutators_state() end
+  --if VT1 then vmf.check_mutators_state() end
 
   if not vmf.all_mods_were_loaded and Managers.mod._state == "done" then
 
@@ -68,8 +68,8 @@ function vmf_mod_object:update(dt)
     vmf.create_network_dictionary()
     vmf.ping_vmf_users()
 
-    if VT1 then vmf.modify_map_view() end
-    if VT1 then vmf.mutators_delete_raw_config() end
+    --if VT1 then vmf.modify_map_view() end
+    --if VT1 then vmf.mutators_delete_raw_config() end
 
     vmf.all_mods_loaded_event()
 

--- a/vmf/scripts/mods/vmf/vmf_loader.lua
+++ b/vmf/scripts/mods/vmf/vmf_loader.lua
@@ -36,6 +36,7 @@ function vmf_mod_object:init()
   dofile("scripts/mods/vmf/modules/ui/chat/chat_actions")
   dofile("scripts/mods/vmf/modules/ui/options/mod_options")
   dofile("scripts/mods/vmf/modules/vmf_options")
+  dofile("scripts/mods/vmf/modules/core/mutators/mutator_manager")
 
   -- if VT1 then
   --   dofile("scripts/mods/vmf/modules/core/mutators/mutators_manager")

--- a/vmf/scripts/mods/vmf/vmf_loader.lua
+++ b/vmf/scripts/mods/vmf/vmf_loader.lua
@@ -92,7 +92,7 @@ end
 function vmf_mod_object:on_reload()
   print("VMF:ON_RELOAD()")
   vmf.disable_mods_options_button()
-  if VT1 then vmf.reset_map_view() end
+  --if VT1 then vmf.reset_map_view() end
   vmf.mods_unload_event(false)
   vmf.network_shutdown()
   vmf.remove_custom_views()


### PR DESCRIPTION
# General

Mutators are mods that somehow alter the game in a way that affects both server and clients.

Unlike regular mods, mutators can be enabled...

- only by the host
- only inside the inn
- only for current session
- only if all conditions required by the mutator is met

Also:

- Mutators can be set to be required on all clients. If such mutator gets enabled on the host, it gets enabled on all clients as well.
- Mutators can have specific toggling order.
  For example, if mutator `B` *(enabled)* is set to be enabled after mutator `A` *(disabled)* and the player attempts to enable `A`, the game will disable `B`, enable `A` and then enable `B` again.
- Mutators can add additional dice for level completion.

# Toggling

Mutators can be toggled in a special menu which only host can see. *(GUI will be done in a separate PR)*

Behavior-wise toggling mutators acts the same way as toggling regular mods. I.e. it affects network, keybindings, etc., and fires `on_enabled` and `on_disabled` events.

If a mutator has `required_on_clients` property set, enabling such mutator will also enable it on all clients.

## Toggling conditions

### All mutators

- Player must be host
- Current level must be inn
- If `mod.can_be_enabled(...)` callback is defined, it must return empty table in order to be able to enable mutator

### Mutators with `required_on_clients` set

- All people in the lobby should be subscribed to togglable mutator
- Nobody should be in the process of joining game
- Server should not be in the process of hosting game

## Firing toggle events

`mod.on_enabled`:

- `[All]` Host manually enables mutator
- `[Clients]` Player is in the process of joining different session, right before level resources start loading

`mod.on_disabled`:

- `[All]` Host manually disables mutator
- `[All]` The mutator is disabled automatically after failed `can_be_enabled` check on host
- `[All]` Player is in the process of joining different session (including host migration), right after previous level resources finish unloading


# Matchmaking

Assuming at least 1 mutator is enabled.

## Global

- `[ASK FATSHARK]` The game is removed from quick play.

## Joining game

### For vanilla players

- [there are no mutators required on client]:
  - Let the player in.
  - Send 2 private messages:
    - Listing current mutators
    - Advising player to install VMF in order to see mutators in lobby browser

- [there are mutators required on client]:
  - Refuse connection.
  - Send private message with missing mutators' names.

### For VMF users

Send the client list of required mutators' IDs and let it perform local checks and decide whether it can connect or not. If client sent missing IDs back, send private message with missing mutators to the player.


# Lobby browser

### For vanilla players

- The server name is appended with `!MODDED!` prefix.
- `[ASK FATSHARK]` A simple switch to filter out modded games.

### For VMF users

*(GUI will be done in a separate  PR)*

![A concept](https://cdn.discordapp.com/attachments/404978161726783491/459598942946983937/mods_lobby_browser.jpg)

- Modded game indicators.
- Tooltip when hovering over a lobby entry listing all active mutators.
- List with active mutators on the right panel with the ability to open every mutator's Steam Workshop page to subscribe to missing mutators.
- Stepper with the ability to filter out specific modded lobbies.


# API changes

### Mod data additions

```lua
{
  --[[ ... ]]
  is_mutator = true, -- optional
  mutator_data = {                   -- optional
    required_on_clients = true,      -- optional
    enable_before = { --[[ ... ]] }, -- optional
    enable_after = { --[[ ... ]] },  -- optional
    dice = {                         -- optional
      bonus = 0, -- required if 'dice' defined
      tomes = 0, -- required if 'dice' defined
      grims = 0  -- required if 'dice' defined
    }
  }
}
```

### New `mod.can_be_enabled(...)` callback

* Is optional.
* Should always return a table.
  * The table is the set of reasons why the mutator can't be enabled.
  * Can be empty.
  * If there's at least 1 reason, the mutator enabling will be forbidden.
  * There are 5 possible reasons:
    ```
    level      [boolean]
    gamemode   [boolean]
    difficulty [boolean]
    mods       [table with mods]
    other      [table with strings]
    ```
    * The reasons will be shown in a tooltip when hovering over the mutator in toggling GUI.
      * All the reasons except `other` are localized by VMF.
* Called
  * For host only.
  * Every tick if mutator is visible in mutator toggling GUI.
  * When the player is in the inn, the mutator is enabled and
    * The target level / gamemode / difficulty is changed.
    * Some mod is toggled.
    * Player starts hosting (or, in case of a random map in VT2, when the player is about to load in the level)
  * When the mutator is disabled because some other mutator is toggled and it has to be enabled again.
  * **[VT1]** Right before voting for the next level (so the voting will be disabled if there is at least one incompatible mutator).

An example:

```lua
function mod.can_be_enabled(level_key, gamemode_key, difficulty_key)
  local incompatibilities = {}

  if not is_compatible(level_key) then
    incompatibilities.level = true
  end
  if not is_compatible(gamemode_key) then
    incompatibilities.gamemode = true
  end
  if not is_compatible(difficulty_key) then
    incompatibilities.difficulty = true
  end

  for _, other_mod_name in ipairs({"some_mod", "some_other_mod", "third_mod"}) do
    local other_mod = get_mod(other_mod_name)
    if other_mod and other_mod:is_enabled() then
      incompatibilities.mods = incompatibilities.mods or {}
      table.insert(incompatibilities.mods, other_mod)
    end
  end

  if some_custom_reason then
    incompatibilities.other = {mod:localize("some_custom_reason")}
  end

  return incompatibilities
end
```

### Changes to `mod.on_enabled(...)` and `mod.on_disabled(...)`

To differentiate if the mutator was toggled locally or remotely, add new boolean parameter `remote_call`.

An example:

```lua
function mod.on_enabled(initial_call, remote_call)
  if remote_call then
    -- The mutator was enabled remotely
  else
    -- The mutator was enabled locally
  end
end
function mod.on_enabled(initial_call, remote_call)
  --[[ ... ]]
end
```

# Some technical details / notes to myself

- All the mutators info is stored inside `lobby_data`, so it's trivial for Fatshark to filter out modded games from quick play and lobby browser.
- **[VT2]** Currently there's no way to remove games from quick play without removing it from lobby browser.
- Loading mutators - launcher's mods order, unloading - reverse. Toggling mutators during reloading have launcher's order.
- Private messages drafts:
  > \>Active mutators: Perfect Dark, Deathwish, Q3DM17

  > \>You can subscribe to Vermintide Mod Framework in Steam Workshop to see active mutators from lobby browser.

  > \>You can't join the game because you're missing required mods: Q3DM17
- Mutators reimplementation:
  - Remove default config. Do proper validation instead, like in custom views.
  - Remove short mutator names.
  - `print` to `vmf:info`?
- *Outdated* snippet I sent someone, may come in handy later:
  ```lua
  on_enabled (true)  -- enabled in midgame/inn after reloading
  on_enabled (false) -- enabled manually (in the inn)
  on_disabled(true)  -- typical launch in disabled state
  on_disabled(false) -- was disabled manually (in the inn)
  on_unload()        -- unloading mid-game
  ```
- Network module changes (expand on it later):
  - Added some extra checks: like registering already registered mod, or sending RPCs to users who don't have the mod, or sending it too early, and some other
  - Firing on_user_left when reloading
  - Additional boolean argument for user joined/left event
  - VMFMod:get_connections, VMFMod:is_connected
  - Sending RPC for disabled mod was allowed

# Some ideas / questions

- How do I retain `remote_call` state between mods reload? What are consequences of reloading on host? On clients?
- How would mutators determine whether they were enabled in-between level loading or not? Does it matter?
- Should I give mutators an ability to tell VMF how they were tweaked so it can be PMd to clients? For example, Deathwish in VT1 have lots of tweaks and can be played very differently.
- How should I implement host migration? Restarting the game without active mutators or going straight to inn? Restarting the game with active mutators is impossible if new host missing some mutators.
  - Retaining enabled mutators and the same map will still trigger mutators enabling/disabling with potential resource loading/unloading because of session switching. Can it lead to some problems? What about custom maps in the future (reloading the same map while fully (un)load map resources)?
  - How can I force going to inn?
- Should there be callbacks for resource loading/unloading in-between level loading?
- Private messages should not be localized, I suppose? Since there's no way to get client's locale.
- Should players see mutators list when pressing tab? How would it be synchronized?
  - [Old notes]: several strings in rect on top in VT1, right-bottom in VT2
- Should host name in VT1 contain active mutators names? Lobby browser has more space for host names compared to VT2 and players are less likely to subscribe to workshop mods.
- From my old notes: "When joining game always check the most recent lobby data and not the one from lobby browser to prevent crashes". How do I get it? Do I even need lobby data? I think I made my own not yet commited shaking system and this note is outdated.

### Proposals

- > If possible, would like to see at least a warning to the modder that they should adjust the mods in their launcher

  > Because it can cause subtle bugs that are a pain in the butt to debug

# TODO

## *For now it's just a bunch of new and old loosely related TODOs in no particular order. I'll update it after some research on what was done and what has to be done.*

- [ ] Find the best moments for enabling and disabling mutators in-between level loading. What are the drawbacks?
  - [ ] Think about disabling order based on `enable_before/after`. Should it involve `can_be_enabled`? Or just LIFO order? (Ignore during reloading)
- [ ] Decide whether incompatible reasons should be an array of localization_ids or already localized string. Discuss with others.
- [ ] Find the best way for host to get list of game altering mods for clients. Network table?
- [ ] How to check game on joining, when it's done from Steam/Friend-list on client-VMF-side?

---

- [ ] Network module refactoring
  - [ ] Finish rpc_inner implementation
    - [ ] Network logging (including reimplementation network-related options)
    - [ ] Workaround for 500 char RPC limit. Find all possible error cases
    - [ ] IIRC, 8 is the max channel number? Check it, document, change code if necessary.
    - [ ] Implement RAW_MOD_RPC
  - [ ] Remove everything related to the old network module implementation
  - [ ] Make limitations section in wiki (Mods RPC):
    - [ ] Aftermath of 500 chars limit workaround
    - [ ] nils -> userdata
    - [ ] [Investigate] Serializable types. I don't think it can serialize mixed tables?
      - [ ] Sparse table limitation. Error if array-like table consists mostly of nils (> half). Also affects arguments
    - [ ] Calling `VMFMod:network_send` with incorrect recipient or specific peer_id right after game start will throw an error because Stingray network manager is not yet initialized and there's no cheap way to check its readiness.

Investigate things in preparation for mutator implementation

- [ ] Does `can_be_enabled` cover absolutely all cases?
- [ ] How can game be removed from quick play?
  - [ ] VT1
  - [ ] VT2
- [ ] Find the best way to store data in LobbyData. Limitations?
  - [ ] Think about lobby browser filtering for vanilla players and VMF users
- [ ] Is it possible for some client to slip into the game with enabled `required_on_clients` mod while not having one?

---

- [ ] Basic Mutators module implementation
  - [ ] Toggling
    - [ ] Add / remove dice
    - [ ] Log it
    - [ ] Add to the list of enabled mutators
    - [ ] If at least one mutator is enabled, alter lobby_data
      - [ ] Add !MODDED! to server name
  - [ ] ?? Add pressing "Play" button events
    - [ ] Send chat broadcast with mod list to everyone
