### PR TITLE
Fix for Hot-Reloading

### DIFF
--- a/vmf/scripts/mods/vmf/modules/gui/custom_views.lua
+++ b/vmf/scripts/mods/vmf/modules/gui/custom_views.lua
@@ -398,4 +398,4 @@ end
 -- #####################################################################################################################
 
 -- If VMF is reloaded mid-game, get ingame_ui.
-_ingame_ui = Managers.matchmaking and Managers.matchmaking[VT1 and "ingame_ui" or "_ingame_ui"]
+_ingame_ui = (VT1 and Managers.matchmaking and Managers.matchmaking.ingame_ui) or (Managers.ui and Managers.ui._ingame_ui)


### PR DESCRIPTION
Changes to MatchmakingManager resulted in VMF having a nil value for _ingame_ui after hot-reloading, breaking all custom views.