### PR TITLE
Enforce 500 character limit on mod rpc data

### DIFF
--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -11,6 +11,7 @@ Contribute to VMF -- add your name here!
 + [Grimalackt](https://github.com/thebotz)
 + [IamLupo](https://github.com/IamLupo)
 + [ManuelBlanc](https://github.com/ManuelBlanc)
++ [Prismism](https://github.com/Vermintide-Analytics)
 + [Shazbot](https://github.com/Shazbot)
 + [SirAiedail](https://github.com/SirAiedail)
 + [UnShame](https://github.com/unshame)

--- a/vmf/scripts/mods/vmf/modules/core/network.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network.lua
@@ -148,7 +148,7 @@ if VT1 then
   end
 else
   local _payload = {"","",""}
-  rpc_chat_message = function(member, channel_id, _, rpc_data1, rpc_data2)	
+  rpc_chat_message = function(member, channel_id, _, rpc_data1, rpc_data2)
     _payload[1] = tostring(channel_id)
     _payload[2] = rpc_data1
     _payload[3] = rpc_data2

--- a/vmf/scripts/mods/vmf/modules/core/network.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network.lua
@@ -165,21 +165,21 @@ end
 local function send_rpc_vmf_pong(peer_id)
 
   network_debug("pong", "sent", peer_id)
-  
+
   local self_peer_id = Network.peer_id()
   local total_blocks = math.ceil(math.max(#_shared_mods_map / MAX_MOD_DATA_LENGTH, #_shared_rpcs_map / MAX_MOD_DATA_LENGTH))
-  
+
   if total_blocks > 1 then
-	rpc_chat_message(peer_id, 4, self_peer_id, "blocks", total_blocks, false, true, false)
-	local last_block_start = (total_blocks-1)*MAX_MOD_DATA_LENGTH + 1 
-	for block_start = 1, last_block_start, MAX_MOD_DATA_LENGTH do
-		local mod_data_block = _shared_mods_map:sub(block_start, block_start + MAX_MOD_DATA_LENGTH - 1)
-		local rpc_data_block = _shared_rpcs_map:sub(block_start, block_start + MAX_MOD_DATA_LENGTH - 1)
-		
-		rpc_chat_message(peer_id, 4, self_peer_id, mod_data_block, rpc_data_block, false, true, false)
-	end
+    rpc_chat_message(peer_id, 4, self_peer_id, "blocks", total_blocks, false, true, false)
+    local last_block_start = (total_blocks-1)*MAX_MOD_DATA_LENGTH + 1
+    for block_start = 1, last_block_start, MAX_MOD_DATA_LENGTH do
+        local mod_data_block = _shared_mods_map:sub(block_start, block_start + MAX_MOD_DATA_LENGTH - 1)
+        local rpc_data_block = _shared_rpcs_map:sub(block_start, block_start + MAX_MOD_DATA_LENGTH - 1)
+
+        rpc_chat_message(peer_id, 4, self_peer_id, mod_data_block, rpc_data_block, false, true, false)
+    end
   else
-	rpc_chat_message(peer_id, 4, self_peer_id, _shared_mods_map, _shared_rpcs_map, false, true, false)
+    rpc_chat_message(peer_id, 4, self_peer_id, _shared_mods_map, _shared_rpcs_map, false, true, false)
   end
 end
 
@@ -314,24 +314,24 @@ local function vmf_network_recv(sender, channel_id, rpc_data1, rpc_data2)
   elseif channel_id == RPC_VMF_RESPONCE_CHANNEL_ID then -- rpc_vmf_responce
     -- @TODO: maybe I should protect it from sending by the player who's not in the game?
 
-	if rpc_data1 == "blocks" then
-		_expected_pong_data_blocks[sender] = tonumber(rpc_data2)
-		_partial_pong_mod_data[sender] = ""
-		_partial_pong_rpc_data[sender] = ""
-	elseif _expected_pong_data_blocks[sender] and _expected_pong_data_blocks[sender] > 0 then
-		_expected_pong_data_blocks[sender] = _expected_pong_data_blocks[sender] - 1
-		_partial_pong_mod_data[sender] = _partial_pong_mod_data[sender] .. rpc_data1
-		_partial_pong_rpc_data[sender] = _partial_pong_rpc_data[sender] .. rpc_data2
-		
-		if _expected_pong_data_blocks[sender] == 0 then
-			vmf_received_full_pong(sender, _partial_pong_mod_data[sender], _partial_pong_rpc_data[sender])
-			_expected_pong_data_blocks[sender] = nil
-			_partial_pong_mod_data[sender] = nil
-			_partial_pong_rpc_data[sender] = nil
-		end
-	else
-		vmf_received_full_pong(sender, rpc_data1, rpc_data2)
-	end
+    if rpc_data1 == "blocks" then
+        _expected_pong_data_blocks[sender] = tonumber(rpc_data2)
+        _partial_pong_mod_data[sender] = ""
+        _partial_pong_rpc_data[sender] = ""
+    elseif _expected_pong_data_blocks[sender] and _expected_pong_data_blocks[sender] > 0 then
+        _expected_pong_data_blocks[sender] = _expected_pong_data_blocks[sender] - 1
+        _partial_pong_mod_data[sender] = _partial_pong_mod_data[sender] .. rpc_data1
+        _partial_pong_rpc_data[sender] = _partial_pong_rpc_data[sender] .. rpc_data2
+
+        if _expected_pong_data_blocks[sender] == 0 then
+            vmf_received_full_pong(sender, _partial_pong_mod_data[sender], _partial_pong_rpc_data[sender])
+            _expected_pong_data_blocks[sender] = nil
+            _partial_pong_mod_data[sender] = nil
+            _partial_pong_rpc_data[sender] = nil
+        end
+    else
+        vmf_received_full_pong(sender, rpc_data1, rpc_data2)
+    end
   elseif channel_id == RPC_VMF_UNKNOWN_CHANNEL_ID then
     local mod_number, rpc_number = unpack(cjson.decode(rpc_data1))
 


### PR DESCRIPTION
Chunk mod list and mod rpc list to maximum length of 500 characters to conform to network limits. This fixes the following error:
```
<<Script Error>>scripts/managers/mod/mod_manager.lua:615: Failed to pack parameter 3, too many characters in string with max length 500<</Script Error>>
<<Lua Stack>>  [1] =[C]: in function rpc_mod_user_data
```

This is becoming increasingly important as some mods have many rpcs and it only takes a handful of mods to exceed this limit.

I wrote this fix in such a way that all scenarios which previously work will still work, even if Steam has not updated VMF for one of the players. So long as the mod/rpc strings are less than 500 characters, the data sent over the network will be exactly the same as before. Only if the data is over 500 characters will the new logic take effect.

I was able to test this with one other person, but not more.