### PR TITLE
Add definition for text settings widgets

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/options.lua
+++ b/vmf/scripts/mods/vmf/modules/core/options.lua
@@ -396,6 +396,46 @@ local function initialize_keybind_data(mod, data, localize)
 end
 
 -- ---------------------------------------------------------------------------------------------------------------------
+-- ----| Text |---------------------------------------------------------------------------------------------------------
+-- ---------------------------------------------------------------------------------------------------------------------
+
+local function validate_text_data(data)
+
+  if data.max_length and type(data.max_length) ~= "number" then
+    vmf.throw_error("[widget \"%s\" (text)]: 'max_length' field must have 'number' type", data.setting_id)
+  end
+  
+  if data.validate and type(data.validate) ~= "function" then
+    vmf.throw_error("[widget \"%s\" (text)]: 'validate' field must have 'function' type", data.setting_id)
+  end
+  
+  local default_value = data.default_value
+  if type(default_value) ~= "string" then
+    vmf.throw_error("[widget \"%s\" (text)]: 'default_value' field is required and must have 'string' type",
+                     data.setting_id)
+  end
+  if data.max_length and #default_value > data.max_length then
+    vmf.throw_error("[widget \"%s\" (text)]: 'default_value' field must have length less than or equal to 'max_length'",
+                     data.setting_id)
+  end
+  if data.validate and not data.validate(default_value) then
+    vmf.throw_error("[widget \"%s\" (text)]: 'default_value' field must pass provided 'validate' function",
+                     data.setting_id)
+  end
+end
+
+local function initialize_text_data(mod, data, localize)
+  local new_data = initialize_generic_widget_data(mod, data, localize)
+
+  new_data.max_length = data.max_length -- optional
+  new_data.validate = data.validate 	-- optional
+
+  validate_text_data(new_data)
+
+  return new_data
+end
+
+-- ---------------------------------------------------------------------------------------------------------------------
 -- ----| Numeric |------------------------------------------------------------------------------------------------------
 -- ---------------------------------------------------------------------------------------------------------------------
 
@@ -476,6 +516,8 @@ local function initialize_widget_data(mod, data, localize, collapsed_widgets)
     return initialize_dropdown_data(mod, data, localize, collapsed_widgets)
   elseif data.type == "keybind" then
     return initialize_keybind_data(mod, data, localize)
+  elseif data.type == "text" then
+    return initialize_text_data(mod, data, localize)
   elseif data.type == "numeric" then
     return initialize_numeric_data(mod, data, localize)
   end

--- a/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
+++ b/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
@@ -2040,10 +2040,10 @@ end
 
 -- ████████╗███████╗██╗  ██╗████████╗
 -- ╚══██╔══╝██╔════╝╚██╗██╔╝╚══██╔══╝
---    ██║   █████╗   ╚███╔╝    ██║   
---    ██║   ██╔══╝   ██╔██╗    ██║   
---    ██║   ███████╗██╔╝ ██╗   ██║   
---    ╚═╝   ╚══════╝╚═╝  ╚═╝   ╚═╝   
+--    ██║   █████╗   ╚███╔╝    ██║
+--    ██║   ██╔══╝   ██╔██╗    ██║
+--    ██║   ███████╗██╔╝ ██╗   ██║
+--    ╚═╝   ╚══════╝╚═╝  ╚═╝   ╚═╝
 
 local function create_text_menu_widget(dropdown_definition, scenegraph_2nd_layer_id)
 
@@ -2294,7 +2294,7 @@ local function create_text_widget(widget_definition, scenegraph_id, scenegraph_2
       mod_name = widget_definition.mod_name,
       setting_id = widget_definition.setting_id,
       widget_type = widget_definition.type,
-      
+
       current_value_text = "whatever",
       default_value = widget_definition.default_value,
       parent_widget_number = widget_definition.parent_index,
@@ -3877,7 +3877,7 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
   local font_material   = font[1]
 
   local new_value = text_menu_content.new_value
-  
+
   local new_value_text              = text_menu_content.new_value_text
 
   local new_value_text_width = UIRenderer.text_size(self.ui_renderer, new_value_text, font_material, font_size, font_name)
@@ -3885,22 +3885,22 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
   text_menu_caret_style.offset[1] = text_menu_text_style.offset[1] - 3
 
   -- calculate selection highlight offset and size ----
-  
+
   local selection = text_menu_content.selection
   local text_menu_selection_style = widget_content.popup_menu_widget.style.selection
   if selection then
     local selected_text = new_value:sub(selection.start, selection.stop)
     local unselected_after = new_value:sub(selection.stop+1, -1)
-    
+
     local highlight_size = UIRenderer.text_size(self.ui_renderer, selected_text, font_material, font_size, font_name)
     local highlight_offset = UIRenderer.text_size(self.ui_renderer, unselected_after, font_material, font_size, font_name)
-    
+
     text_menu_selection_style.size[1] = highlight_size
     text_menu_selection_style.offset[1] = text_menu_text_style.offset[1] - (highlight_size + highlight_offset)
   else
     text_menu_selection_style.size[1] = 0
   end
-  
+
 
   -- blink caret ---------------------------------------
 
@@ -3941,7 +3941,7 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
         text_menu_content.selection = nil
     end
   end
-  
+
   local new_value_is_valid = (not widget_content.max_length or (#new_value <= widget_content.max_length)) and (not widget_content.validate or widget_content.validate(new_value))
 
   if new_value_is_valid then
@@ -3979,12 +3979,12 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
   if Mouse.released(0) and not widget_content.wrong_mouse_on_release or Keyboard.released(13) then
     self:callback_change_text_menu_visibility(widget_content)
     text_menu_content.selection = nil
-    
+
     if new_value_is_valid then
         widget_content.current_value = new_value
         widget_content.current_value_text = widget_content.current_value
     end
-    
+
     return true
   end
 

--- a/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
+++ b/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
@@ -2098,12 +2098,12 @@ local function create_text_menu_widget(dropdown_definition, scenegraph_2nd_layer
         offset = {offset_x, offset_y - size_y, 20},
         color = {255, 20, 20, 20}
       },
-	  selection = {
-	    size = {0, 25},
-		offset = {offset_x, dropdown_definition.style.current_value_text.offset[2] + 10, 21},
-		color = {255, 40, 40, 40},
+      selection = {
+        size = {0, 25},
+        offset = {offset_x, dropdown_definition.style.current_value_text.offset[2] + 10, 21},
+        color = {255, 40, 40, 40},
         horizontal_alignment = "right"
-	  },
+      },
       new_value_text = {
         offset = {
           dropdown_definition.style.current_value_text.offset[1],
@@ -2294,7 +2294,7 @@ local function create_text_widget(widget_definition, scenegraph_id, scenegraph_2
       mod_name = widget_definition.mod_name,
       setting_id = widget_definition.setting_id,
       widget_type = widget_definition.type,
-	  
+      
       current_value_text = "whatever",
       default_value = widget_definition.default_value,
       parent_widget_number = widget_definition.parent_index,
@@ -3894,11 +3894,11 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
     
     local highlight_size = UIRenderer.text_size(self.ui_renderer, selected_text, font_material, font_size, font_name)
     local highlight_offset = UIRenderer.text_size(self.ui_renderer, unselected_after, font_material, font_size, font_name)
-	
-	text_menu_selection_style.size[1] = highlight_size
-	text_menu_selection_style.offset[1] = text_menu_text_style.offset[1] - (highlight_size + highlight_offset)
+    
+    text_menu_selection_style.size[1] = highlight_size
+    text_menu_selection_style.offset[1] = text_menu_text_style.offset[1] - (highlight_size + highlight_offset)
   else
-	text_menu_selection_style.size[1] = 0
+    text_menu_selection_style.size[1] = 0
   end
   
 
@@ -3915,39 +3915,39 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
 
   for _, stroke in ipairs(keystrokes) do
     if type(stroke) == "string" then
-	  new_value = new_value .. stroke
+      new_value = new_value .. stroke
     elseif stroke == Keyboard.BACKSPACE or stroke == Keyboard.DELETE then
       if #new_value > 0 then
-	    if selection then
-		  new_value = new_value:sub(0, selection.start-1) .. new_value:sub(selection.stop+1, -1)
-		  text_menu_content.selection = nil
-		else
-		  new_value = new_value:sub(1, -2)
-		end
+        if selection then
+          new_value = new_value:sub(0, selection.start-1) .. new_value:sub(selection.stop+1, -1)
+          text_menu_content.selection = nil
+        else
+          new_value = new_value:sub(1, -2)
+        end
       end
     elseif stroke == 1 and (Keyboard.button(Keyboard.button_id("left ctrl")) or Keyboard.button(Keyboard.button_id("right ctrl"))) then -- Ctrl+A
-	  if #new_value > 0 then
-	    text_menu_content.selection = {
-		  ["start"] = 1,
-		  ["stop"] = #new_value
-		}
-	  end
+      if #new_value > 0 then
+        text_menu_content.selection = {
+          ["start"] = 1,
+          ["stop"] = #new_value
+        }
+      end
     elseif stroke == 22 and (Keyboard.button(Keyboard.button_id("left ctrl")) or Keyboard.button(Keyboard.button_id("right ctrl"))) then -- Ctrl+V
-	  local clipboard = Clipboard.get() or ""
-	  if Utf8.valid(clipboard) then
-	    new_value = new_value .. clipboard
-	  end
-	elseif stroke == Keyboard.LEFT or stroke == Keyboard.RIGHT then
-		text_menu_content.selection = nil
-	end
+      local clipboard = Clipboard.get() or ""
+      if Utf8.valid(clipboard) then
+        new_value = new_value .. clipboard
+      end
+    elseif stroke == Keyboard.LEFT or stroke == Keyboard.RIGHT then
+        text_menu_content.selection = nil
+    end
   end
   
   local new_value_is_valid = (not widget_content.max_length or (#new_value <= widget_content.max_length)) and (not widget_content.validate or widget_content.validate(new_value))
 
   if new_value_is_valid then
-	text_menu_text_style.text_color = {255, 255, 255, 255}
+    text_menu_text_style.text_color = {255, 255, 255, 255}
   else
-	text_menu_text_style.text_color = {255, 255, 70, 70}
+    text_menu_text_style.text_color = {255, 255, 70, 70}
   end
 
   -- ASSIGNING VALUES ##################################
@@ -3979,12 +3979,12 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
   if Mouse.released(0) and not widget_content.wrong_mouse_on_release or Keyboard.released(13) then
     self:callback_change_text_menu_visibility(widget_content)
     text_menu_content.selection = nil
-	
+    
     if new_value_is_valid then
-		widget_content.current_value = new_value
-		widget_content.current_value_text = widget_content.current_value
+        widget_content.current_value = new_value
+        widget_content.current_value_text = widget_content.current_value
     end
-	
+    
     return true
   end
 
@@ -3992,7 +3992,7 @@ VMFOptionsView.callback_draw_text_menu = function (self, widget_content)
 
   if Keyboard.released(27) then
     self:callback_change_text_menu_visibility(widget_content)
-	text_menu_content.selection = nil
+    text_menu_content.selection = nil
   end
 
   widget_content.wrong_mouse_on_release = nil
@@ -4402,7 +4402,7 @@ VMFOptionsView.update_picked_option_for_settings_list_widgets = function (self)
         end
 
         widget_content.keybind_text = vmf.build_keybind_string(widget_content.keys)
-	  elseif widget_type == "text" then
+      elseif widget_type == "text" then
 
         loaded_setting_value = get_mod(widget_content.mod_name):get(widget_content.setting_id)
 


### PR DESCRIPTION
1. Started by copying numeric widget code
2. Removed properties specific to numbers, such as range and units, as well as their corresponding UI
3. Added optional max_length and validate properties which apply restrictions to input
4. Changed horizontal alignment to "right" so that the user can always see the rightmost text they are typing. The text can still get cut off outside the settings window for longer inputs.
5. Added the ability to select all characters so that backspace/delete will delete them all, instead of having to remove 1 character at a time. Selection is visually highlighted with a slightly lighter gray box.