### PR TITLE
Allow special characters in mod settings search

### DIFF
--- a/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
+++ b/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
@@ -4052,7 +4052,7 @@ VMFOptionsView.update_search_bar = function (self)
 
     local new_search_text = KeystrokeHelper.parse_strokes(old_search_text, text_index, "insert", keystrokes)
 
-	-- Prepend % [ ] ( ) . + - * ? ^ $ with % to allow users to search on special pattern characters
+    -- Prepend % [ ] ( ) . + - * ? ^ $ with % to allow users to search on special pattern characters
     local new_search_text_escaped = new_search_text:gsub("([%%%[%]%(%)%.%+%-%*%?%^%$])", "%%%1")
 
     if new_search_text ~= old_search_text then

--- a/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
+++ b/vmf/scripts/mods/vmf/modules/ui/options/vmf_options_view.lua
@@ -4052,10 +4052,11 @@ VMFOptionsView.update_search_bar = function (self)
 
     local new_search_text = KeystrokeHelper.parse_strokes(old_search_text, text_index, "insert", keystrokes)
 
-    new_search_text = string.gsub(new_search_text, "%%", "")
+	-- Prepend % [ ] ( ) . + - * ? ^ $ with % to allow users to search on special pattern characters
+    local new_search_text_escaped = new_search_text:gsub("([%%%[%]%(%)%.%+%-%*%?%^%$])", "%%%1")
 
     if new_search_text ~= old_search_text then
-      self:filter_mods_settings_by_name(new_search_text)
+      self:filter_mods_settings_by_name(new_search_text_escaped)
     end
 
     widget_content.text = new_search_text


### PR DESCRIPTION
Previously, users could not type % in the search bar. Typing [, ], (, or ) would crash, and . + - * ? ^ $ were not escaped so you could not search for those characters, but instead they would perform their typical Lua pattern functions which would be confusing to the user.

Simply escape all of these characters so that the user can search for them if they want, and no more crashes!