### PR TITLE
Check local_player_id when removing players

### DIFF
--- a/vmf/scripts/mods/vmf/modules/core/network.lua
+++ b/vmf/scripts/mods/vmf/modules/core/network.lua
@@ -372,7 +372,7 @@ vmf:hook(PlayerManager, "add_remote_player", function (func, self, peer_id, play
   return func(self, peer_id, player_controlled, ...)
 end)
 
-vmf:hook(PlayerManager, "remove_player", function (func, self, peer_id, ...)
+vmf:hook(PlayerManager, "remove_player", function (func, self, peer_id, local_player_id, ...)
 
   _expected_pong_data_blocks[peer_id] = nil
   _partial_pong_mod_data[peer_id] = nil
@@ -382,7 +382,7 @@ vmf:hook(PlayerManager, "remove_player", function (func, self, peer_id, ...)
 
     -- make sure it's not the bot
     for _, player in pairs(Managers.player:human_players()) do
-      if player.peer_id == peer_id then
+      if player.peer_id == peer_id and player:local_player_id() == local_player_id then
 
         vmf:info("Removed %s from the VMF users list.", peer_id)
 
@@ -400,7 +400,7 @@ vmf:hook(PlayerManager, "remove_player", function (func, self, peer_id, ...)
     end
   end
 
-  func(self, peer_id, ...)
+  func(self, peer_id, local_player_id, ...)
 end)
 
 -- ####################################################################################################################


### PR DESCRIPTION
Previously, if a bot is removed, the logic to remove the host still would trigger, causing RPCs to not be sent to the host from clients for the rest of that game.

This *actually* filters out bots.

Tested as client:

Before the fix, if a bot (local_player_id  6, where host is local_player_id 1) is removed, VMF will remove the host from the client's list of peers, resulting in no RPCs sent to the host.
```
07:26:25.613 [Lua] [MOD][VMF][INFO] Removed 1100001066b2b42 from the VMF users list.
07:26:25.613 [Lua] PlayerManager:remove_player peer_id=1100001066b2b42 6
```

After the fix, VMF no longer removes the host (I added a debug message to verify the new logic was being hit as expected).
```
04:21:11.127 [Lua] [MOD][VMF][ECHO] EXPERIMENTAL VMF: Detected bot removal which normally would have removed the host, but not doing that anymore!
04:21:11.127 [Lua] PlayerManager:remove_player peer_id=1100001066b2b42 6
```
